### PR TITLE
Dependencies - Mint should be optional

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Exth.MixProject do
     [
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:jason, "~> 1.4"},
-      {:mint, "~> 1.7", only: :dev},
+      {:mint, "~> 1.7", optional: true},
       {:tesla, "~> 1.14"}
     ]
   end


### PR DESCRIPTION
So far we were using `mint` only in `:dev`, but this was not intended.
We want to make `mint` optional:
> `:optional` - marks the dependency as optional. In such cases, the current project will always include the optional dependency but any other project that depends on the current project won't be forced to use the optional dependency. However, if the other project includes the optional dependency on its own, the requirements and options specified here will also be applied. Optional dependencies will not be started by the application. You should consider compiling your projects with the mix compile --no-optional-deps --warnings-as-errors during test, to ensure your project compiles without warnings even if optional dependencies are missing