### PR TITLE
Make RPC functions pipeable

### DIFF
--- a/examples/multichain.exs
+++ b/examples/multichain.exs
@@ -1,5 +1,8 @@
 Mix.install([{:exth, path: "../"}, :mint])
 
+# Be cautious when running this example. The RPC URLs are public and may be
+# rate-limited or unstable.
+
 defmodule MyProvider do
   defmodule Eth do
     use Exth.Provider,
@@ -18,16 +21,18 @@ require Logger
 
 vitalik_address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
-Enum.each([MyProvider.Eth, MyProvider.Polygon], fn provider -> 
+Enum.each([MyProvider.Eth, MyProvider.Polygon], fn provider ->
   {:ok, block_number} = provider.block_number()
   {:ok, balance} = provider.get_balance(vitalik_address, block_number)
   Logger.info("#{provider}: block_number: #{block_number}")
   Logger.info("#{provider}: get_balance: #{balance}")
 end)
 
-
 # Using RPC client directly
 client = MyProvider.Eth.get_client()
-request = Exth.Rpc.request(client, "eth_blockNumber", [])
-{:ok, response} = Exth.Rpc.send(client, request)
+
+{:ok, response} =
+  Exth.Rpc.request("eth_blockNumber", [])
+  |> Exth.Rpc.send(client)
+
 Logger.info("RPC: eth_blockNumber: #{inspect(response)}")

--- a/lib/exth/provider.ex
+++ b/lib/exth/provider.ex
@@ -205,10 +205,10 @@ defmodule Exth.Provider do
               ) :: rpc_response()
         def unquote(method_name)(unquote_splicing(function_params)) do
           client = get_client()
-          request = Rpc.request(client, unquote(rpc_method), [unquote_splicing(request_params)])
 
-          client
-          |> Rpc.send(request)
+          unquote(rpc_method)
+          |> Rpc.request([unquote_splicing(request_params)])
+          |> Rpc.send(client)
           |> handle_response()
         end
       end
@@ -243,6 +243,7 @@ defmodule Exth.Provider do
       This caching mechanism helps reduce connection overhead and
       maintain connection pooling efficiency.
       """
+      @spec get_client() :: Rpc.Client.t()
       def get_client do
         transport_type = Keyword.fetch!(@provider_opts, :transport_type)
         rpc_url = Keyword.fetch!(@provider_opts, :rpc_url)

--- a/lib/exth/rpc.ex
+++ b/lib/exth/rpc.ex
@@ -69,6 +69,21 @@ defmodule Exth.Rpc do
   defdelegate request(client, method, params), to: Client
 
   @doc """
+  Builds a new JSON-RPC request for the given method and parameters.
+
+  The request will automatically:
+    * Set the protocol version to "2.0"
+    * Format parameters according to the JSON-RPC spec
+
+  ## Examples
+
+      request = Rpc.request("eth_blockNumber", [])
+      request = Rpc.request("eth_getBalance", ["0x742d...", "latest"])
+  """
+  @spec request(method(), params(), id()) :: Request.t()
+  defdelegate request(method, params), to: Client
+
+  @doc """
   Sends a JSON-RPC request using the client's configured transport.
   Supports both single requests and batch requests.
 
@@ -88,7 +103,7 @@ defmodule Exth.Rpc do
       # Error handling
       {:error, reason} = Rpc.send(client, bad_request)
   """
-  @spec send(Client.t(), Request.t() | [Request.t()]) ::
+  @spec send(Client.t() | Request.t() | [Request.t()], Client.t() | Request.t() | [Request.t()]) ::
           {:ok, Response.t() | [Response.t()]} | {:error, Exception.t()}
   defdelegate send(client, request), to: Client
 end

--- a/lib/exth/rpc.ex
+++ b/lib/exth/rpc.ex
@@ -2,15 +2,75 @@ defmodule Exth.Rpc do
   @moduledoc """
   Core module for making JSON-RPC requests to EVM-compatible blockchain nodes.
 
-  Provides a simple interface for creating clients, building requests, and handling
-  responses using different transport options.
+  This module provides a comprehensive interface for interacting with JSON-RPC endpoints,
+  offering flexible request building, multiple transport options, and robust error handling.
+
+  ## Key Features
+
+    * Client-based and standalone request building
+    * Batch request support for better performance
+    * Configurable transport layers (HTTP, custom implementations)
+    * Automatic request ID generation and version management
+    * Flexible JSON encoding/decoding options
+    * Comprehensive error handling
 
   ## Quick Start
 
+      # Create a client
       client = Rpc.new_client(:http, rpc_url: "https://eth-mainnet.example.com")
 
-      request = Rpc.request(client, "eth_blockNumber", [])
+      # Make a simple request
+      request = Rpc.request("eth_blockNumber", [])
       {:ok, response} = Rpc.send(client, request)
+
+  ## Request Patterns
+
+  ### Client-based Requests
+      # Create client once and reuse
+      client = Rpc.new_client(:http, rpc_url: "https://eth-mainnet.example.com")
+      
+      # Make requests with client
+      request = Rpc.request(client, "eth_getBalance", ["0x742d...", "latest"])
+      {:ok, response} = Rpc.send(client, request)
+
+  ### Standalone Requests
+      # Build requests without client
+      request = Rpc.request("eth_blockNumber", [])
+      {:ok, response} = Rpc.send(client, request)
+
+  ### Batch Requests
+      # Send multiple requests in one call
+      requests = [
+        Rpc.request("eth_blockNumber", []),
+        Rpc.request("eth_gasPrice", [])
+      ]
+      {:ok, [block_response, gas_response]} = Rpc.send(client, requests)
+
+  ## Transport Configuration
+
+  The module supports different transport layers:
+
+    * `:http` - Standard HTTP/HTTPS transport with configurable headers and timeouts
+    * `:custom` - Custom transport implementations for special needs
+
+  ## Error Handling
+
+      case Rpc.send(client, request) do
+        {:ok, response} -> 
+          # Handle successful response
+          handle_success(response.result)
+        
+        {:error, %{code: code, message: msg}} -> 
+          # Handle RPC-level errors
+          handle_rpc_error(code, msg)
+        
+        {:error, %Exception{} = e} -> 
+          # Handle transport-level errors
+          handle_transport_error(e)
+      end
+
+  See the individual function documentation for more detailed usage examples
+  and options.
   """
 
   alias __MODULE__.Client
@@ -53,55 +113,107 @@ defmodule Exth.Rpc do
   defdelegate new_client(type, opts), to: Client, as: :new
 
   @doc """
-  Builds a new JSON-RPC request for the given method and parameters.
+  Builds a new JSON-RPC request using a client for the given method and parameters.
 
-  The request will automatically:
+  When using a client, the request will automatically:
     * Set the protocol version to "2.0"
-    * Generate a unique request ID
+    * Generate a unique request ID based on the client's ID sequence
     * Format parameters according to the JSON-RPC spec
+
+  The client-based request ensures that each request gets a unique ID within
+  the client's context, which is important for correlating responses in batch
+  requests or concurrent operations.
 
   ## Examples
 
+      # Simple request with no parameters - includes client-generated ID
       request = Rpc.request(client, "eth_blockNumber", [])
+      # => %Request{id: 1, method: "eth_blockNumber", params: []}
+
+      # Request with multiple parameters - next ID in sequence
       request = Rpc.request(client, "eth_getBalance", ["0x742d...", "latest"])
+      # => %Request{id: 2, method: "eth_getBalance", params: ["0x742d...", "latest"]}
+
+      # The request can be later used with Rpc.send/2
+      {:ok, response} = Rpc.send(client, request)
   """
   @spec request(Client.t(), method(), params()) :: Request.t()
   defdelegate request(client, method, params), to: Client
 
   @doc """
-  Builds a new JSON-RPC request for the given method and parameters.
+  Builds a new JSON-RPC request without requiring a client instance.
 
-  The request will automatically:
+  This is a convenience function for creating requests that can be later used
+  with a client. Useful when building multiple requests before sending them.
+
+  When creating a standalone request, it will:
     * Set the protocol version to "2.0"
+    * Leave the request ID as nil (it will be set when used with a client)
     * Format parameters according to the JSON-RPC spec
+
+  The ID-less request allows for flexibility, as the actual ID will be assigned
+  by the client when the request is sent, ensuring proper ID sequencing within
+  the client's context.
 
   ## Examples
 
-      request = Rpc.request("eth_blockNumber", [])
-      request = Rpc.request("eth_getBalance", ["0x742d...", "latest"])
+      # Create standalone requests - no IDs yet
+      request1 = Rpc.request("eth_blockNumber", [])
+      # => %Request{id: nil, method: "eth_blockNumber", params: []}
+
+      request2 = Rpc.request("eth_getBalance", ["0x742d...", "latest"])
+      # => %Request{id: nil, method: "eth_getBalance", params: ["0x742d...", "latest"]}
+
+      # When sent with a client, IDs will be assigned
+      {:ok, response} = Rpc.send(client, request1)
+      # request1 now has id: 1
+
+      # In batch requests, each request gets a sequential ID
+      {:ok, responses} = Rpc.send(client, [request1, request2])
+      # request1 has id: 2, request2 has id: 3
   """
-  @spec request(method(), params(), id()) :: Request.t()
+  @spec request(method(), params()) :: Request.t()
   defdelegate request(method, params), to: Client
 
   @doc """
-  Sends a JSON-RPC request using the client's configured transport.
-  Supports both single requests and batch requests.
+  Sends one or more JSON-RPC requests using the client's configured transport.
+
+  This function is the main interface for executing requests. It handles both
+  single and batch requests automatically, with proper error handling and response
+  decoding.
+
+  ## Request Types
+    * Single request: Pass a single Request.t()
+    * Batch request: Pass a list of Request.t()
 
   ## Returns
     * `{:ok, response}` - Successful single request with decoded response
-    * `{:ok, responses}` - Successful batch request with list of responses
+    * `{:ok, responses}` - Successful batch request with list of decoded responses
     * `{:error, reason}` - Request failed with error details (Exception.t() or map())
 
   ## Examples
 
       # Single request
       {:ok, response} = Rpc.send(client, request)
+      block_number = response.result
 
-      # Batch request
-      {:ok, responses} = Rpc.send(client, [request1, request2])
-      
+      # Batch request for better performance
+      requests = [
+        Rpc.request("eth_blockNumber", []),
+        Rpc.request("eth_gasPrice", [])
+      ]
+      {:ok, [block_response, gas_response]} = Rpc.send(client, requests)
+
+      # You can also invert the arguments
+      Rpc.request("eth_blockNumber", [])
+      |> Rpc.send(client)
+
       # Error handling
-      {:error, reason} = Rpc.send(client, bad_request)
+      case Rpc.send(client, request) do
+        {:ok, response} -> handle_success(response)
+        {:error, %{code: code, message: msg}} -> handle_rpc_error(code, msg)
+        {:error, %Exception{} = e} -> handle_transport_error(e)
+      end
   """
   @spec send(Client.t() | Request.t() | [Request.t()], Client.t() | Request.t() | [Request.t()]) ::
           {:ok, Response.t() | [Response.t()]} | {:error, Exception.t()}

--- a/lib/exth/rpc/client.ex
+++ b/lib/exth/rpc/client.ex
@@ -133,7 +133,7 @@ defmodule Exth.Rpc.Client do
   @spec request(t(), Rpc.method(), Rpc.params()) :: Request.t()
   def request(%__MODULE__{} = client, method, params)
       when is_binary(method) or is_atom(method) do
-    id = next_id(client)
+    id = generate_id(client)
     Request.new(method, params, id)
   end
 
@@ -142,27 +142,78 @@ defmodule Exth.Rpc.Client do
     Request.new(method, params)
   end
 
-  @spec send(t() | Request.t() | [Request.t()], t() | Request.t() | [Request.t()]) ::
-          {:ok, Response.t()} | {:error, Exception.t()}
-  def send(%__MODULE__{} = client, %Request{id: nil} = request) do
-    request = %Request{request | id: next_id(client)}
-    __MODULE__.send(client, request)
-  end
-
-  def send(%Request{id: nil} = request, %__MODULE__{} = client) do
-    request = %Request{request | id: next_id(client)}
-    __MODULE__.send(client, request)
-  end
-
+  @spec send(t() | Request.t() | [Request.t()] | [], t() | Request.t() | [Request.t()] | []) ::
+          {:ok, Response.t()} | {:error, Exception.t() | :duplicate_ids}
   def send(%__MODULE__{} = client, %Request{} = request) do
-    Transport.call(client.transport, request)
+    send_single(client, request)
   end
 
   def send(%Request{} = request, %__MODULE__{} = client) do
+    send_single(client, request)
+  end
+
+  def send(%__MODULE__{} = client, requests) when is_list(requests) do
+    send_batch(client, requests)
+  end
+
+  def send(requests, %__MODULE__{} = client) when is_list(requests) do
+    send_batch(client, requests)
+  end
+
+  ###
+  ### Private Functions
+  ###
+
+  defp send_single(%__MODULE__{} = client, %Request{} = request) do
+    request =
+      if is_nil(request.id) do
+        %Request{request | id: generate_id(client)}
+      else
+        request
+      end
+
     Transport.call(client.transport, request)
   end
 
-  defp next_id(%__MODULE__{counter: counter}) do
+  defp send_batch(%__MODULE__{}, []), do: {:ok, []}
+
+  defp send_batch(%__MODULE__{} = client, requests) do
+    with :ok <- validate_unique_ids(requests) do
+      requests = assign_missing_ids(client, requests)
+      Transport.call(client.transport, requests)
+    end
+  end
+
+  defp validate_unique_ids(requests) do
+    existing_ids = requests |> Enum.map(& &1.id) |> Enum.reject(&is_nil/1)
+
+    if length(existing_ids) == length(Enum.uniq(existing_ids)) do
+      :ok
+    else
+      {:error, :duplicate_ids}
+    end
+  end
+
+  defp assign_missing_ids(client, requests) do
+    existing_ids = MapSet.new(requests, & &1.id)
+
+    Enum.map(requests, fn request ->
+      if is_nil(request.id) do
+        %Request{request | id: generate_unique_id(client, existing_ids)}
+      else
+        request
+      end
+    end)
+  end
+
+  defp generate_unique_id(client, existing_ids) do
+    client
+    |> generate_id()
+    |> Stream.iterate(fn _ -> generate_id(client) end)
+    |> Enum.find(fn id -> not MapSet.member?(existing_ids, id) end)
+  end
+
+  defp generate_id(%__MODULE__{counter: counter}) do
     :atomics.add_get(counter, 1, 1)
   end
 end

--- a/lib/exth/rpc/request.ex
+++ b/lib/exth/rpc/request.ex
@@ -11,17 +11,20 @@ defmodule Exth.Rpc.Request do
         }
 
   defstruct [
-    :id,
     :method,
+    id: nil,
     params: [],
     jsonrpc: Rpc.jsonrpc_version()
   ]
 
-  @spec new(Rpc.method(), Rpc.params(), Rpc.id()) :: t()
-  def new(method, params, id) do
+  @spec new(Rpc.method(), Rpc.params(), Rpc.id() | nil) :: t()
+  def new(method, params, id \\ nil) do
     validate_method(method)
     validate_params(params)
-    validate_id(id)
+
+    if not is_nil(id) do
+      validate_id(id)
+    end
 
     %__MODULE__{
       method: method,

--- a/test/exth/rpc/client_test.exs
+++ b/test/exth/rpc/client_test.exs
@@ -101,6 +101,39 @@ defmodule Exth.Rpc.ClientTest do
     end
   end
 
+  describe "request/2" do
+    test "creates a request with string method" do
+      request = Client.request("eth_blockNumber", [])
+      assert %Request{} = request
+      assert request.method == "eth_blockNumber"
+      assert request.params == []
+      assert is_nil(request.id)
+      assert request.jsonrpc == "2.0"
+    end
+
+    test "creates a request with atom method" do
+      request = Client.request(:eth_blockNumber, [])
+      assert %Request{} = request
+      assert request.method == :eth_blockNumber
+      assert request.params == []
+      assert is_nil(request.id)
+      assert request.jsonrpc == "2.0"
+    end
+
+    test "handles various parameter types" do
+      params = [
+        "0x123",
+        123,
+        true,
+        %{key: "value"},
+        ["0x456", false]
+      ]
+
+      request = Client.request("eth_call", params)
+      assert request.params == params
+    end
+  end
+
   describe "send/2" do
     setup do
       client = Client.new(:custom, module: TestTransport, rpc_url: @valid_url)
@@ -193,11 +226,11 @@ defmodule Exth.Rpc.ClientTest do
     end
 
     test "validates request input", %{client: client} do
-      assert_raise Protocol.UndefinedError, fn ->
+      assert_raise FunctionClauseError, fn ->
         Client.send(client, nil)
       end
 
-      assert_raise Protocol.UndefinedError, fn ->
+      assert_raise FunctionClauseError, fn ->
         Client.send(client, "not_a_request")
       end
     end

--- a/test/exth/rpc/client_test.exs
+++ b/test/exth/rpc/client_test.exs
@@ -140,6 +140,74 @@ defmodule Exth.Rpc.ClientTest do
       {:ok, client: client}
     end
 
+    test "accepts request first, client second", %{client: client} do
+      request = Client.request("eth_blockNumber", [])
+      assert {:ok, response} = Client.send(request, client)
+      assert %Response.Success{} = response
+      assert response.result =~ ~r/^0x[0-9a-f]+$/
+      assert is_integer(response.id)
+    end
+
+    test "accepts requests list first, client second", %{client: client} do
+      requests = [
+        Client.request("eth_blockNumber", []),
+        Client.request("eth_chainId", [])
+      ]
+
+      assert {:ok, responses} = Client.send(requests, client)
+      assert length(responses) == 2
+      assert Enum.all?(responses, &match?(%Response.Success{}, &1))
+    end
+
+    test "handles batch requests with pre-assigned IDs", %{client: client} do
+      requests = [
+        %Request{Client.request("eth_blockNumber", []) | id: 42},
+        %Request{Client.request("eth_chainId", []) | id: 43}
+      ]
+
+      assert {:ok, responses} = Client.send(client, requests)
+      assert length(responses) == 2
+      assert Enum.map(responses, & &1.id) == [42, 43]
+    end
+
+    test "detects duplicate IDs in batch requests", %{client: client} do
+      requests = [
+        %Request{Client.request("eth_blockNumber", []) | id: 42},
+        %Request{Client.request("eth_chainId", []) | id: 42}
+      ]
+
+      assert {:error, :duplicate_ids} = Client.send(client, requests)
+    end
+
+    test "assigns unique IDs to nil ID requests in batch", %{client: client} do
+      requests = [
+        Client.request("eth_blockNumber", []),
+        Client.request("eth_chainId", []),
+        %Request{Client.request("eth_gasPrice", []) | id: 42}
+      ]
+
+      assert {:ok, responses} = Client.send(client, requests)
+
+      ids = Enum.map(responses, & &1.id)
+      assert length(Enum.uniq(ids)) == 3
+      assert 42 in ids
+    end
+
+    test "preserves existing IDs while assigning new ones in batch", %{client: client} do
+      requests = [
+        %Request{Client.request("eth_blockNumber", []) | id: 42},
+        Client.request("eth_chainId", []),
+        Client.request("eth_gasPrice", [])
+      ]
+
+      assert {:ok, responses} = Client.send(client, requests)
+
+      ids = Enum.map(responses, & &1.id)
+      assert length(Enum.uniq(ids)) == 3
+      assert 42 in ids
+      assert Enum.all?(ids -- [42], &(&1 != 42))
+    end
+
     test "sends single requests successfully", %{client: client} do
       for method <- @test_methods do
         params = if method == "eth_getBalance", do: [@test_address, "latest"], else: []

--- a/test/exth/rpc/request_test.exs
+++ b/test/exth/rpc/request_test.exs
@@ -55,7 +55,6 @@ defmodule Exth.Rpc.RequestTest do
 
     test "raises when id is not a positive integer" do
       invalid_ids = [
-        nil,
         0,
         -1,
         "1",


### PR DESCRIPTION
This PR:
- adds `request/2` to `Exth.Rpc` and `Exth.Rpc.Client`. This is a way to create a `Request` without ID;
- changes `Exth.Rpc` and `Exth.Rpc.Client` `send/2` function to allow inverting argument. This way a request can be the 1st argument and a client can be the 2nd, allowing for piping request creation and execution;
- `send/2` is also aware of colliding IDs in batch requests and returns an error;
- improve overall `Exth.Rpc` docs;

From now on, we can do things like:
```elixir
"eth_blockNumber"
|> Rpc.request([])
|> Rpc.send(client)
```