### PR TITLE
Refactor Provider domain to reduce its complexity

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -86,7 +86,7 @@
           ### Remove max_complexity: 12 when we have time to refactor
           ### Default is 9
           ###
-          {Credo.Check.Refactor.CyclomaticComplexity, [max_complexity: 12]},
+          {Credo.Check.Refactor.CyclomaticComplexity},
           {Credo.Check.Refactor.FilterCount, []},
           {Credo.Check.Refactor.FilterFilter, []},
           {Credo.Check.Refactor.FunctionArity, []},

--- a/lib/exth/provider.ex
+++ b/lib/exth/provider.ex
@@ -79,6 +79,11 @@ defmodule Exth.Provider do
   See `Exth.Provider.Methods` for a complete list of available RPC methods.
   """
 
+  alias Exth.Provider.ClientCache
+  alias Exth.Provider.Methods
+  alias Exth.Rpc
+  alias Exth.Rpc.Response
+
   @required_opts [:transport_type, :rpc_url]
 
   @doc """
@@ -158,61 +163,74 @@ defmodule Exth.Provider do
   """
   defmacro generate_provider(opts) do
     quote bind_quoted: [opts: opts] do
-      alias Exth.Provider.ClientCache
-      alias Exth.Provider.Methods
-      alias Exth.Rpc
-      alias Exth.Rpc.Response
-
       @type rpc_response :: {:ok, term()} | {:error, term()}
 
       @default_block_tag "latest"
       @provider_opts opts
 
       for {method_name, {rpc_method, param_types, accepts_block}} <- Methods.methods() do
-        param_vars = Enum.map(param_types, &Macro.var(&1, nil))
-
-        {function_params, request_params} =
-          if accepts_block do
-            block_param = Macro.var(:block_tag, nil)
-            function_params = param_vars ++ [{:\\, [], [block_param, @default_block_tag]}]
-            request_params = param_vars ++ [block_param]
-            {function_params, request_params}
-          else
-            {param_vars, param_vars}
-          end
-
-        param_docs = Enum.map_join(param_types, "\n* ", &"#{&1}")
-
-        param_docs =
-          if accepts_block,
-            do:
-              param_docs <>
-                "\n* block_tag - Block number or tag (default: \"#{@default_block_tag}\")",
-            else: param_docs
-
-        @doc """
-        Executes the #{rpc_method} JSON-RPC method.
-
-        ## Parameters
-        * #{param_docs}
-
-        ## Returns
-          * `{:ok, response}` - Successful request with decoded response
-          * `{:error, reason}` - Request failed with error details
-        """
-        @spec unquote(method_name)(
-                unquote_splicing(param_types |> Enum.map(fn _ -> quote do: term() end))
-              ) :: rpc_response()
-        def unquote(method_name)(unquote_splicing(function_params)) do
-          client = get_client()
-
-          unquote(rpc_method)
-          |> Rpc.request([unquote_splicing(request_params)])
-          |> Rpc.send(client)
-          |> handle_response()
-        end
+        Exth.Provider.generate_rpc_method(method_name, rpc_method, param_types, accepts_block)
       end
 
+      Exth.Provider.generate_get_client()
+      Exth.Provider.generate_handle_response()
+    end
+  end
+
+  defmacro generate_rpc_method(method_name, rpc_method, param_types, accepts_block) do
+    quote bind_quoted: [
+            method_name: method_name,
+            rpc_method: rpc_method,
+            param_types: param_types,
+            accepts_block: accepts_block
+          ] do
+      param_vars = Enum.map(param_types, &Macro.var(&1, nil))
+
+      {function_params, request_params} =
+        if accepts_block do
+          block_param = Macro.var(:block_tag, nil)
+          function_params = param_vars ++ [{:\\, [], [block_param, @default_block_tag]}]
+          request_params = param_vars ++ [block_param]
+          {function_params, request_params}
+        else
+          {param_vars, param_vars}
+        end
+
+      param_docs = Enum.map_join(param_types, "\n* ", &"#{&1}")
+
+      param_docs =
+        if accepts_block,
+          do:
+            param_docs <>
+              "\n* block_tag - Block number or tag (default: \"#{@default_block_tag}\")",
+          else: param_docs
+
+      @doc """
+      Executes the #{rpc_method} JSON-RPC method.
+
+      ## Parameters
+      * #{param_docs}
+
+      ## Returns
+        * `{:ok, response}` - Successful request with decoded response
+        * `{:error, reason}` - Request failed with error details
+      """
+      @spec unquote(method_name)(
+              unquote_splicing(param_types |> Enum.map(fn _ -> quote do: term() end))
+            ) :: rpc_response()
+      def unquote(method_name)(unquote_splicing(function_params)) do
+        client = get_client()
+
+        unquote(rpc_method)
+        |> Rpc.request([unquote_splicing(request_params)])
+        |> Rpc.send(client)
+        |> handle_response()
+      end
+    end
+  end
+
+  defmacro generate_get_client do
+    quote do
       @doc """
       Retrieves or creates a new RPC client instance.
 
@@ -257,7 +275,11 @@ defmodule Exth.Provider do
             ClientCache.create_client(transport_type, rpc_url, client)
         end
       end
+    end
+  end
 
+  defmacro generate_handle_response do
+    quote do
       defp handle_response({:ok, %Response.Success{} = response}), do: {:ok, response.result}
       defp handle_response({:ok, %Response.Error{} = response}), do: {:error, response.error}
       defp handle_response({:error, reason} = response) when is_binary(reason), do: response

--- a/lib/exth/provider.ex
+++ b/lib/exth/provider.ex
@@ -79,8 +79,6 @@ defmodule Exth.Provider do
   See `Exth.Provider.Methods` for a complete list of available RPC methods.
   """
 
-  @required_opts [:transport_type, :rpc_url]
-
   @doc """
   Implements the provider behavior in the using module.
 
@@ -101,41 +99,14 @@ defmodule Exth.Provider do
       end
   """
   defmacro __using__(opts) do
-    quote bind_quoted: [opts: opts, required_opts: @required_opts] do
+    quote bind_quoted: [opts: opts] do
       alias Exth.Provider
 
       require Provider.Generator
+      require Provider.Validator
 
-      Provider.validate_options!(opts, required_opts)
+      Provider.Validator.validate_options!(opts)
       Provider.Generator.generate_provider(opts)
-    end
-  end
-
-  @doc """
-  Validates the configuration options provided to the provider.
-
-  This macro ensures that all required options are present and have valid values.
-  It raises an `ArgumentError` if any required options are missing.
-
-  ## Parameters
-
-    * `opts` - Keyword list of provider options
-    * `required_opts` - List of required option keys
-
-  ## Raises
-
-    * `ArgumentError` - When required options are missing
-  """
-  defmacro validate_options!(opts, required_opts) do
-    quote bind_quoted: [opts: opts, required_opts: required_opts] do
-      missing_opts = Enum.reject(required_opts, &Keyword.has_key?(opts, &1))
-
-      unless Enum.empty?(missing_opts) do
-        raise ArgumentError, """
-        Missing required options: #{inspect(missing_opts)}
-        Required options: #{inspect(required_opts)}
-        """
-      end
     end
   end
 end

--- a/lib/exth/provider.ex
+++ b/lib/exth/provider.ex
@@ -79,11 +79,6 @@ defmodule Exth.Provider do
   See `Exth.Provider.Methods` for a complete list of available RPC methods.
   """
 
-  alias Exth.Provider.ClientCache
-  alias Exth.Provider.Methods
-  alias Exth.Rpc
-  alias Exth.Rpc.Response
-
   @required_opts [:transport_type, :rpc_url]
 
   @doc """
@@ -107,8 +102,12 @@ defmodule Exth.Provider do
   """
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts, required_opts: @required_opts] do
-      Exth.Provider.validate_options!(opts, required_opts)
-      Exth.Provider.generate_provider(opts)
+      alias Exth.Provider
+
+      require Provider.Generator
+
+      Provider.validate_options!(opts, required_opts)
+      Provider.Generator.generate_provider(opts)
     end
   end
 
@@ -137,153 +136,6 @@ defmodule Exth.Provider do
         Required options: #{inspect(required_opts)}
         """
       end
-    end
-  end
-
-  @doc """
-  Generates the provider module with all RPC method implementations.
-
-  This macro creates the actual provider implementation by:
-    * Setting up the client cache
-    * Generating functions for each RPC method
-    * Implementing response handling
-    * Creating helper functions
-
-  ## Parameters
-
-    * `opts` - Keyword list of provider options
-
-  ## Generated Functions
-
-  For each RPC method defined in `Exth.Provider.Methods`, this macro generates:
-    * A public function with proper type specs
-    * Documentation with parameters and return values
-    * Automatic parameter validation
-    * Response handling and formatting
-  """
-  defmacro generate_provider(opts) do
-    quote bind_quoted: [opts: opts] do
-      @type rpc_response :: {:ok, term()} | {:error, term()}
-
-      @default_block_tag "latest"
-      @provider_opts opts
-
-      for {method_name, {rpc_method, param_types, accepts_block}} <- Methods.methods() do
-        Exth.Provider.generate_rpc_method(method_name, rpc_method, param_types, accepts_block)
-      end
-
-      Exth.Provider.generate_get_client()
-      Exth.Provider.generate_handle_response()
-    end
-  end
-
-  defmacro generate_rpc_method(method_name, rpc_method, param_types, accepts_block) do
-    quote bind_quoted: [
-            method_name: method_name,
-            rpc_method: rpc_method,
-            param_types: param_types,
-            accepts_block: accepts_block
-          ] do
-      param_vars = Enum.map(param_types, &Macro.var(&1, nil))
-
-      {function_params, request_params} =
-        if accepts_block do
-          block_param = Macro.var(:block_tag, nil)
-          function_params = param_vars ++ [{:\\, [], [block_param, @default_block_tag]}]
-          request_params = param_vars ++ [block_param]
-          {function_params, request_params}
-        else
-          {param_vars, param_vars}
-        end
-
-      param_docs = Enum.map_join(param_types, "\n* ", &"#{&1}")
-
-      param_docs =
-        if accepts_block,
-          do:
-            param_docs <>
-              "\n* block_tag - Block number or tag (default: \"#{@default_block_tag}\")",
-          else: param_docs
-
-      @doc """
-      Executes the #{rpc_method} JSON-RPC method.
-
-      ## Parameters
-      * #{param_docs}
-
-      ## Returns
-        * `{:ok, response}` - Successful request with decoded response
-        * `{:error, reason}` - Request failed with error details
-      """
-      @spec unquote(method_name)(
-              unquote_splicing(param_types |> Enum.map(fn _ -> quote do: term() end))
-            ) :: rpc_response()
-      def unquote(method_name)(unquote_splicing(function_params)) do
-        client = get_client()
-
-        unquote(rpc_method)
-        |> Rpc.request([unquote_splicing(request_params)])
-        |> Rpc.send(client)
-        |> handle_response()
-      end
-    end
-  end
-
-  defmacro generate_get_client do
-    quote do
-      @doc """
-      Retrieves or creates a new RPC client instance.
-
-      This function manages the lifecycle of RPC clients by:
-        * First attempting to fetch an existing client from the cache
-        * Creating and caching a new client if none exists
-
-      The client is uniquely identified by the combination of:
-        * transport_type (e.g., :http)
-        * rpc_url (the endpoint URL)
-
-      ## Returns
-
-        * `client` - A configured RPC client instance
-
-      ## Examples
-
-          # Automatically called by RPC methods
-          client = MyProvider.get_client()
-
-      ## Cache Behavior
-
-      The function implements a "get or create" pattern:
-        1. Attempts to fetch a cached client
-        2. If no cached client exists, creates a new one
-        3. New clients are automatically cached for future use
-
-      This caching mechanism helps reduce connection overhead and
-      maintain connection pooling efficiency.
-      """
-      @spec get_client() :: Rpc.Client.t()
-      def get_client do
-        transport_type = Keyword.fetch!(@provider_opts, :transport_type)
-        rpc_url = Keyword.fetch!(@provider_opts, :rpc_url)
-
-        case ClientCache.get_client(transport_type, rpc_url) do
-          {:ok, client} ->
-            client
-
-          {:error, :not_found} ->
-            client = Rpc.new_client(transport_type, @provider_opts)
-            ClientCache.create_client(transport_type, rpc_url, client)
-        end
-      end
-    end
-  end
-
-  defmacro generate_handle_response do
-    quote do
-      defp handle_response({:ok, %Response.Success{} = response}), do: {:ok, response.result}
-      defp handle_response({:ok, %Response.Error{} = response}), do: {:error, response.error}
-      defp handle_response({:error, reason} = response) when is_binary(reason), do: response
-      defp handle_response({:error, reason}), do: {:error, inspect(reason)}
     end
   end
 end

--- a/lib/exth/provider/generator.ex
+++ b/lib/exth/provider/generator.ex
@@ -1,0 +1,161 @@
+defmodule Exth.Provider.Generator do
+  @moduledoc false
+
+  alias Exth.Provider
+  alias Exth.Provider.ClientCache
+  alias Exth.Provider.Methods
+  alias Exth.Rpc
+  alias Exth.Rpc.Response
+
+  @doc """
+  Generates the provider module with all RPC method implementations.
+
+  This macro creates the actual provider implementation by:
+    * Setting up the client cache
+    * Generating functions for each RPC method
+    * Implementing response handling
+    * Creating helper functions
+
+  ## Parameters
+
+    * `opts` - Keyword list of provider options
+
+  ## Generated Functions
+
+  For each RPC method defined in `Exth.Provider.Methods`, this macro generates:
+    * A public function with proper type specs
+    * Documentation with parameters and return values
+    * Automatic parameter validation
+    * Response handling and formatting
+  """
+  defmacro generate_provider(opts) do
+    quote bind_quoted: [opts: opts] do
+      @type rpc_response :: {:ok, term()} | {:error, term()}
+
+      @default_block_tag "latest"
+      @provider_opts opts
+
+      for {method_name, {rpc_method, param_types, accepts_block}} <- Methods.methods() do
+        Provider.Generator.generate_rpc_method(
+          method_name,
+          rpc_method,
+          param_types,
+          accepts_block
+        )
+      end
+
+      Provider.Generator.generate_get_client()
+      Provider.Generator.generate_handle_response()
+    end
+  end
+
+  defmacro generate_rpc_method(method_name, rpc_method, param_types, accepts_block) do
+    quote bind_quoted: [
+            method_name: method_name,
+            rpc_method: rpc_method,
+            param_types: param_types,
+            accepts_block: accepts_block
+          ] do
+      param_vars = Enum.map(param_types, &Macro.var(&1, nil))
+
+      {function_params, request_params} =
+        if accepts_block do
+          block_param = Macro.var(:block_tag, nil)
+          function_params = param_vars ++ [{:\\, [], [block_param, @default_block_tag]}]
+          request_params = param_vars ++ [block_param]
+          {function_params, request_params}
+        else
+          {param_vars, param_vars}
+        end
+
+      param_docs = Enum.map_join(param_types, "\n* ", &"#{&1}")
+
+      param_docs =
+        if accepts_block,
+          do:
+            param_docs <>
+              "\n* block_tag - Block number or tag (default: \"#{@default_block_tag}\")",
+          else: param_docs
+
+      @doc """
+      Executes the #{rpc_method} JSON-RPC method.
+
+      ## Parameters
+      * #{param_docs}
+
+      ## Returns
+        * `{:ok, response}` - Successful request with decoded response
+        * `{:error, reason}` - Request failed with error details
+      """
+      @spec unquote(method_name)(
+              unquote_splicing(param_types |> Enum.map(fn _ -> quote do: term() end))
+            ) :: rpc_response()
+      def unquote(method_name)(unquote_splicing(function_params)) do
+        client = get_client()
+
+        unquote(rpc_method)
+        |> Rpc.request([unquote_splicing(request_params)])
+        |> Rpc.send(client)
+        |> handle_response()
+      end
+    end
+  end
+
+  defmacro generate_get_client do
+    quote do
+      @doc """
+      Retrieves or creates a new RPC client instance.
+
+      This function manages the lifecycle of RPC clients by:
+        * First attempting to fetch an existing client from the cache
+        * Creating and caching a new client if none exists
+
+      The client is uniquely identified by the combination of:
+        * transport_type (e.g., :http)
+        * rpc_url (the endpoint URL)
+
+      ## Returns
+
+        * `client` - A configured RPC client instance
+
+      ## Examples
+
+          # Automatically called by RPC methods
+          client = MyProvider.get_client()
+
+      ## Cache Behavior
+
+      The function implements a "get or create" pattern:
+        1. Attempts to fetch a cached client
+        2. If no cached client exists, creates a new one
+        3. New clients are automatically cached for future use
+
+      This caching mechanism helps reduce connection overhead and
+      maintain connection pooling efficiency.
+      """
+      @spec get_client() :: Rpc.Client.t()
+      def get_client do
+        transport_type = Keyword.fetch!(@provider_opts, :transport_type)
+        rpc_url = Keyword.fetch!(@provider_opts, :rpc_url)
+
+        case ClientCache.get_client(transport_type, rpc_url) do
+          {:ok, client} ->
+            client
+
+          {:error, :not_found} ->
+            client = Rpc.new_client(transport_type, @provider_opts)
+            ClientCache.create_client(transport_type, rpc_url, client)
+        end
+      end
+    end
+  end
+
+  defmacro generate_handle_response do
+    quote do
+      defp handle_response({:ok, %Response.Success{} = response}), do: {:ok, response.result}
+      defp handle_response({:ok, %Response.Error{} = response}), do: {:error, response.error}
+      defp handle_response({:error, reason} = response) when is_binary(reason), do: response
+      defp handle_response({:error, reason}), do: {:error, inspect(reason)}
+    end
+  end
+end

--- a/lib/exth/provider/validator.ex
+++ b/lib/exth/provider/validator.ex
@@ -1,0 +1,33 @@
+defmodule Exth.Provider.Validator do
+  @moduledoc false
+
+  @required_opts [:transport_type, :rpc_url]
+
+  @doc """
+  Validates the configuration options provided to the provider.
+
+  This macro ensures that all required options are present and have valid values.
+  It raises an `ArgumentError` if any required options are missing.
+
+  ## Parameters
+
+    * `opts` - Keyword list of provider options
+    * `required_opts` - List of required option keys
+
+  ## Raises
+
+    * `ArgumentError` - When required options are missing
+  """
+  defmacro validate_options!(opts) do
+    quote bind_quoted: [opts: opts, required_opts: @required_opts] do
+      missing_opts = Enum.reject(required_opts, &Keyword.has_key?(opts, &1))
+
+      unless Enum.empty?(missing_opts) do
+        raise ArgumentError, """
+        Missing required options: #{inspect(missing_opts)}
+        Required options: #{inspect(required_opts)}
+        """
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR:
- moves Provider generation code to a `Generator` module;
- moves Provider validation code to a `Validator` module;
- removes the cyclomatic `max_complexity` value to the default value. That's because we split provider code and reduce its complexity.