### PR TITLE
Fix Provider Dialyzer warning `has no local return`

### DIFF
--- a/lib/exth/provider/generator.ex
+++ b/lib/exth/provider/generator.ex
@@ -152,9 +152,10 @@ defmodule Exth.Provider.Generator do
 
   defmacro generate_handle_response do
     quote do
+      @spec handle_response(Rpc.Client.send_response_type()) ::
+              {:ok, term()} | {:error, term()}
       defp handle_response({:ok, %Response.Success{} = response}), do: {:ok, response.result}
       defp handle_response({:ok, %Response.Error{} = response}), do: {:error, response.error}
-      defp handle_response({:error, reason} = response) when is_binary(reason), do: response
       defp handle_response({:error, reason}), do: {:error, inspect(reason)}
     end
   end

--- a/lib/exth/rpc.ex
+++ b/lib/exth/rpc.ex
@@ -75,12 +75,11 @@ defmodule Exth.Rpc do
 
   alias __MODULE__.Client
   alias __MODULE__.Request
-  alias __MODULE__.Response
   alias Exth.Transport
 
   @type id :: pos_integer()
   @type jsonrpc :: String.t()
-  @type method :: String.t()
+  @type method :: atom() | String.t()
   @type params :: list(binary())
 
   @jsonrpc_version "2.0"
@@ -215,7 +214,7 @@ defmodule Exth.Rpc do
         {:error, %Exception{} = e} -> handle_transport_error(e)
       end
   """
-  @spec send(Client.t() | Request.t() | [Request.t()], Client.t() | Request.t() | [Request.t()]) ::
-          {:ok, Response.t() | [Response.t()]} | {:error, Exception.t()}
+  @spec send(Client.send_argument_type(), Client.send_argument_type()) ::
+          Client.send_response_type()
   defdelegate send(arg1, arg2), to: Client
 end

--- a/lib/exth/rpc/client.ex
+++ b/lib/exth/rpc/client.ex
@@ -97,7 +97,6 @@ defmodule Exth.Rpc.Client do
   alias Exth.Rpc
   alias Exth.Rpc.Encoding
   alias Exth.Rpc.Request
-  alias Exth.Rpc.Response
   alias Exth.Transport
   alias Exth.Transport.Transportable
 
@@ -142,8 +141,10 @@ defmodule Exth.Rpc.Client do
     Request.new(method, params)
   end
 
-  @spec send(t() | Request.t() | [Request.t()] | [], t() | Request.t() | [Request.t()] | []) ::
-          {:ok, Response.t()} | {:error, Exception.t() | :duplicate_ids}
+  @type send_argument_type :: t() | Request.t() | [Request.t()] | []
+  @type send_response_type :: Transport.call_response() | {:error, :duplicate_ids}
+
+  @spec send(send_argument_type(), send_argument_type()) :: send_response_type()
   def send(%__MODULE__{} = client, %Request{} = request) do
     send_single(client, request)
   end

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -169,6 +169,7 @@ defmodule Exth.Transport do
   end
 
   @type error_reason :: Exception.t() | String.t() | term()
+  @type call_response :: {:ok, Response.t() | [Response.t()]} | {:error, error_reason()}
 
   @doc """
   Makes a request using the configured transport.
@@ -181,7 +182,6 @@ defmodule Exth.Transport do
     * `{:ok, response}` - Successful request with decoded response
     * `{:error, reason}` - Request failed with error reason
   """
-  @spec call(Transportable.t(), Request.t() | [Request.t()]) ::
-          {:ok, Response.t() | [Response.t()]} | {:error, error_reason()}
+  @spec call(Transportable.t(), Request.t() | [Request.t()]) :: call_response()
   def call(transportable, request), do: Transportable.call(transportable, request)
 end


### PR DESCRIPTION
This PR fixes the type system and dialyzer warning: `has no local return`

Resolves: #50 