### PR TITLE
Add serialize/1 function to Request module

### DIFF
--- a/lib/exth/rpc.ex
+++ b/lib/exth/rpc.ex
@@ -99,7 +99,6 @@ defmodule Exth.Rpc do
 
   ## Options
     * `:rpc_url` - (Required) The endpoint URL
-    * `:encoder` - Function to encode requests to JSON
     * `:decoder` - Function to decode JSON responses
     * `:headers` - Additional HTTP headers (HTTP transport only)
     * `:timeout` - Request timeout in ms (HTTP transport only)

--- a/lib/exth/rpc/client.ex
+++ b/lib/exth/rpc/client.ex
@@ -39,7 +39,6 @@ defmodule Exth.Rpc.Client do
     * `:transport_type` - Transport to use (`:http` or `:custom`)
     * `:timeout` - Request timeout in milliseconds
     * `:headers` - Additional HTTP headers (HTTP only)
-    * `:encoder` - Custom request encoder (defaults to JSON)
     * `:decoder` - Custom response decoder (defaults to JSON)
 
   ## Request ID Generation
@@ -121,10 +120,8 @@ defmodule Exth.Rpc.Client do
   end
 
   defp build_opts(opts) do
-    encoder = &Encoding.encode_request/1
     decoder = &Encoding.decode_response/1
-
-    base_opts = Keyword.new(encoder: encoder, decoder: decoder)
+    base_opts = Keyword.new(decoder: decoder)
 
     Keyword.merge(base_opts, opts)
   end

--- a/lib/exth/rpc/encoding.ex
+++ b/lib/exth/rpc/encoding.ex
@@ -48,26 +48,6 @@ defmodule Exth.Rpc.Encoding do
 
   ## Usage
 
-  Encoding single requests:
-
-      request = %Request{
-        jsonrpc: "2.0",
-        method: "eth_blockNumber",
-        params: [],
-        id: 1
-      }
-
-      {:ok, json} = Encoding.encode_request(request)
-
-  Encoding batch requests:
-
-      requests = [
-        %Request{method: "eth_blockNumber", id: 1},
-        %Request{method: "eth_gasPrice", id: 2}
-      ]
-
-      {:ok, json} = Encoding.encode_request(requests)
-
   Decoding responses:
 
       {:ok, response} = Encoding.decode_response(json)
@@ -89,14 +69,6 @@ defmodule Exth.Rpc.Encoding do
     * Protocol version mismatch
 
   ## Examples
-
-      # Encode a single request
-      request = %Request{
-        method: "eth_blockNumber",
-        params: [],
-        id: 1
-      }
-      {:ok, json} = Encoding.encode_request(request)
 
       # Decode a success response
       {:ok, response} = Encoding.decode_response(~s({
@@ -120,7 +92,7 @@ defmodule Exth.Rpc.Encoding do
         %Request{method: "eth_blockNumber", id: 1},
         %Request{method: "eth_gasPrice", id: 2}
       ]
-      {:ok, json} = Encoding.encode_request(requests)
+      {:ok, json} = Request.serialize(requests)
       {:ok, responses} = Encoding.decode_response(json)
 
   ## Implementation Notes
@@ -135,23 +107,7 @@ defmodule Exth.Rpc.Encoding do
   `Exth.Rpc.Response` for response handling.
   """
 
-  alias Exth.Rpc.Request
   alias Exth.Rpc.Response
-
-  @spec encode_request(Request.t() | [Request.t()]) :: {:ok, String.t()} | {:error, Exception.t()}
-  def encode_request(%Request{} = request) do
-    request
-    |> do_encode_request()
-    |> json_encode()
-  end
-
-  def encode_request(requests) when is_list(requests) do
-    requests
-    |> Enum.map(&do_encode_request/1)
-    |> json_encode()
-  end
-
-  defp do_encode_request(%Request{} = request), do: Map.from_struct(request)
 
   @spec decode_response(String.t()) ::
           {:ok, Response.t() | [Response.t()]} | {:error, Exception.t()}
@@ -188,12 +144,5 @@ defmodule Exth.Rpc.Encoding do
 
   defp do_decode_response(response) do
     {:error, "invalid response: #{inspect(response)}"}
-  end
-
-  defp json_encode(data) do
-    encoded = JSON.encode!(data)
-    {:ok, encoded}
-  rescue
-    _ -> {:error, "encoding of #{inspect(data)} failed"}
   end
 end

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -42,7 +42,6 @@ defmodule Exth.Transport do
   Common options for all transports:
 
     * `:rpc_url` - (Required) The endpoint URL
-    * `:encoder` - (Required) Function to encode requests to JSON
     * `:decoder` - (Required) Function to decode JSON responses
 
   HTTP-specific options:
@@ -124,7 +123,6 @@ defmodule Exth.Transport do
   """
   @type options :: [
           rpc_url: String.t(),
-          encoder: (term -> String.t()),
           decoder: (String.t() -> term),
           module: module() | nil
         ]
@@ -154,7 +152,6 @@ defmodule Exth.Transport do
 
   defp validate_opts(opts) do
     opts[:rpc_url] || raise ArgumentError, "missing required option :rpc_url"
-    opts[:encoder] || raise ArgumentError, "missing required option :encoder"
     opts[:decoder] || raise ArgumentError, "missing required option :decoder"
   end
 

--- a/test/exth/rpc/encoding_test.exs
+++ b/test/exth/rpc/encoding_test.exs
@@ -25,24 +25,6 @@ defmodule Exth.Rpc.EncodingTest do
       end
     end
 
-    test "new/3 raises on invalid inputs" do
-      assert_raise ArgumentError, "invalid method: cannot be nil", fn ->
-        Request.new(nil, [], 1)
-      end
-
-      assert_raise ArgumentError, "invalid method: cannot be empty", fn ->
-        Request.new("", [], 1)
-      end
-
-      assert_raise ArgumentError, "invalid params: must be a list", fn ->
-        Request.new("method", nil, 1)
-      end
-
-      assert_raise ArgumentError, "invalid id: must be a positive integer", fn ->
-        Request.new("method", [], 0)
-      end
-    end
-
     test "encodes batch requests with different sizes" do
       test_cases = [
         [build_request("method1")],

--- a/test/exth/rpc/request_test.exs
+++ b/test/exth/rpc/request_test.exs
@@ -3,6 +3,21 @@ defmodule Exth.Rpc.RequestTest do
 
   alias Exth.Rpc.Request
 
+  describe "new/2" do
+    test "creates a request without an id" do
+      method = "eth_getBalance"
+      params = ["0x123", "latest"]
+
+      request = Request.new(method, params)
+
+      assert %Request{} = request
+      assert request.method == method
+      assert request.params == params
+      assert is_nil(request.id)
+      assert request.jsonrpc == "2.0"
+    end
+  end
+
   describe "new/3" do
     test "creates a request with all fields" do
       method = "eth_getBalance"
@@ -111,5 +126,125 @@ defmodule Exth.Rpc.RequestTest do
       assert request.id == nil
       assert request.method == nil
     end
+  end
+
+  describe "serialize/1" do
+    test "encodes requests with various parameter types" do
+      test_cases = [
+        {build_request("eth_blockNumber"), []},
+        {build_request("eth_getBalance", ["0x123", "latest"]), ["0x123", "latest"]},
+        {build_request("eth_call", [%{"to" => "0x123"}]), [%{"to" => "0x123"}]},
+        {build_request("eth_getLogs", [[1, 2, 3]]), [[1, 2, 3]]},
+        {build_request("test_method", [true, 42, "string"]), [true, 42, "string"]}
+      ]
+
+      for {request, expected_params} <- test_cases do
+        assert {:ok, json} = Request.serialize(request)
+        assert {:ok, decoded} = JSON.decode(json)
+        assert_valid_jsonrpc(decoded)
+        assert decoded["method"] == request.method
+        assert decoded["params"] == expected_params
+        assert decoded["id"] == request.id
+      end
+    end
+
+    test "encodes batch requests with different sizes" do
+      test_cases = [
+        [build_request("method1")],
+        [build_request("method1"), build_request("method2", [], 2)],
+        [
+          build_request("method1"),
+          build_request("method2", ["param"], 2),
+          build_request("method3", [%{"key" => "value"}], 3)
+        ]
+      ]
+
+      for requests <- test_cases do
+        assert {:ok, json} = Request.serialize(requests)
+        assert {:ok, decoded} = JSON.decode(json)
+        assert length(decoded) == length(requests)
+        assert_valid_jsonrpc(decoded)
+
+        Enum.zip(requests, decoded)
+        |> Enum.each(fn {req, dec} ->
+          assert dec["method"] == req.method
+          assert dec["params"] == req.params
+          assert dec["id"] == req.id
+        end)
+      end
+    end
+
+    test "encodes a single request" do
+      request = %Request{
+        method: "eth_blockNumber",
+        params: [],
+        id: 1
+      }
+
+      assert {:ok, json} = Request.serialize(request)
+      assert {:ok, decoded} = JSON.decode(json)
+
+      assert decoded == %{
+               "jsonrpc" => "2.0",
+               "method" => "eth_blockNumber",
+               "params" => [],
+               "id" => 1
+             }
+    end
+
+    test "encodes a request with params" do
+      request = %Request{
+        method: "eth_getBalance",
+        params: ["0x123", "latest"],
+        id: 2
+      }
+
+      assert {:ok, json} = Request.serialize(request)
+      assert {:ok, decoded} = JSON.decode(json)
+
+      assert decoded == %{
+               "jsonrpc" => "2.0",
+               "method" => "eth_getBalance",
+               "params" => ["0x123", "latest"],
+               "id" => 2
+             }
+    end
+
+    test "encodes a batch of requests" do
+      requests = [
+        %Request{method: "eth_blockNumber", params: [], id: 1},
+        %Request{method: "eth_gasPrice", params: [], id: 2}
+      ]
+
+      assert {:ok, json} = Request.serialize(requests)
+      assert {:ok, decoded} = JSON.decode(json)
+
+      assert decoded == [
+               %{
+                 "jsonrpc" => "2.0",
+                 "method" => "eth_blockNumber",
+                 "params" => [],
+                 "id" => 1
+               },
+               %{
+                 "jsonrpc" => "2.0",
+                 "method" => "eth_gasPrice",
+                 "params" => [],
+                 "id" => 2
+               }
+             ]
+    end
+  end
+
+  defp build_request(method, params \\ [], id \\ 1) do
+    Request.new(method, params, id)
+  end
+
+  defp assert_valid_jsonrpc(decoded) when is_map(decoded) do
+    assert decoded["jsonrpc"] == "2.0"
+  end
+
+  defp assert_valid_jsonrpc(decoded) when is_list(decoded) do
+    Enum.each(decoded, &assert_valid_jsonrpc/1)
   end
 end

--- a/test/exth/transport/http_test.exs
+++ b/test/exth/transport/http_test.exs
@@ -48,18 +48,6 @@ defmodule Exth.Transport.HttpTest do
       end
     end
 
-    test "validates encoder function", %{opts: opts} do
-      opts = Keyword.delete(opts, :encoder)
-
-      assert_raise ArgumentError, ~r/encoder function is required/, fn ->
-        Http.new(opts)
-      end
-
-      assert_raise ArgumentError, ~r/Invalid encoder/, fn ->
-        Http.new(opts |> Keyword.put(:encoder, "not a function"))
-      end
-    end
-
     test "validates decoder function", %{opts: opts} do
       opts = Keyword.delete(opts, :decoder)
 

--- a/test/exth/transport_test.exs
+++ b/test/exth/transport_test.exs
@@ -21,7 +21,7 @@ defmodule Exth.TransportTest do
     end
 
     test "validates base transport requirements" do
-      required_opts = [:rpc_url, :encoder, :decoder]
+      required_opts = [:rpc_url, :decoder]
 
       for opt <- required_opts do
         opts = valid_transport_opts() |> Keyword.delete(opt)

--- a/test/support/fixtures/transport_fixtures.ex
+++ b/test/support/fixtures/transport_fixtures.ex
@@ -6,7 +6,6 @@ defmodule Exth.TransportFixtures do
   def valid_transport_opts do
     [
       rpc_url: "https://example.com",
-      encoder: &Encoding.encode_request/1,
       decoder: &Encoding.decode_response/1
     ]
   end


### PR DESCRIPTION
This PR moves the logic of `Encoding.encode_request/1` to `Request.serialize/1`, as it makes more sense and is more intuitive.