### PR TITLE
Add RPC Call struct for pipeable operations in the Client

### DIFF
--- a/examples/lib/examples.ex
+++ b/examples/lib/examples.ex
@@ -22,10 +22,10 @@ defmodule Examples do
     |> Enum.map(fn provider -> {provider, provider.get_client()} end)
     |> Enum.each(fn {provider, client} ->
       {:ok, %Rpc.Response.Success{result: block_number}} =
-        Rpc.request("eth_blockNumber", []) |> Rpc.send(client)
+        client |> Rpc.request("eth_blockNumber", []) |> Rpc.send()
 
       {:ok, %Rpc.Response.Success{result: balance}} =
-        Rpc.request("eth_getBalance", [address, block_number]) |> Rpc.send(client)
+        client |> Rpc.request("eth_getBalance", [address, block_number]) |> Rpc.send()
 
       Logger.info("#{provider} Client: block_number: #{block_number}")
       Logger.info("#{provider} Client: get_balance: #{balance}")

--- a/lib/exth/provider.ex
+++ b/lib/exth/provider.ex
@@ -232,11 +232,9 @@ defmodule Exth.Provider do
               unquote_splicing(param_types |> Enum.map(fn _ -> quote do: term() end))
             ) :: rpc_response()
       def unquote(method_name)(unquote_splicing(function_params)) do
-        client = get_client()
-
-        unquote(rpc_method)
-        |> Rpc.request([unquote_splicing(request_params)])
-        |> Rpc.send(client)
+        get_client()
+        |> Rpc.request(unquote(rpc_method), [unquote_splicing(request_params)])
+        |> Rpc.send()
         |> handle_response()
       end
     end

--- a/lib/exth/rpc/call.ex
+++ b/lib/exth/rpc/call.ex
@@ -1,0 +1,126 @@
+defmodule Exth.Rpc.Call do
+  @moduledoc """
+  Represents a chain of RPC calls that can be executed in sequence or as a batch.
+
+  This module provides a fluent API for making RPC calls, allowing you to chain multiple
+  requests together before executing them. The calls can be executed either as individual
+  requests or as a batch request.
+
+  ## Fields
+
+    * `client` - The RPC client used to make the requests
+    * `requests` - List of requests to be executed
+
+  ## Examples
+
+      # Create a new call chain
+      call = Call.new(client)
+
+      # Add requests to the chain
+      call
+      |> Call.add_request("eth_blockNumber", [])
+      |> Call.add_request("eth_getBalance", ["0x742d35Cc6634C0532925a3b844Bc454e4438f44e", "latest"])
+
+      # Get the list of requests
+      requests = Call.get_requests(call)
+      # => [
+      #   %Request{method: "eth_blockNumber", params: [], id: 1},
+      #   %Request{method: "eth_getBalance", params: ["0x742d...", "latest"], id: 2}
+      # ]
+
+      # Get the associated client
+      client = Call.get_client(call)
+      # => %Client{...}
+  """
+
+  alias Exth.Rpc.Client
+  alias Exth.Rpc.Request
+  alias Exth.Rpc.Types
+
+  @type t :: %__MODULE__{
+          client: Client.t(),
+          requests: [Request.t()]
+        }
+
+  defstruct [
+    :client,
+    requests: []
+  ]
+
+  @doc """
+  Creates a new RpcCall with the given client.
+
+  ## Parameters
+    * `client` - The RPC client to use for making requests
+
+  ## Returns
+    * A new `Call` struct with the given client and an empty list of requests
+
+  ## Examples
+      client = %Client{...}
+      call = Call.new(client)
+      # => %Call{client: client, requests: []}
+  """
+  @spec new(Client.t()) :: t()
+  def new(client) do
+    %__MODULE__{client: client}
+  end
+
+  @doc """
+  Adds a new request to the call chain.
+
+  ## Parameters
+    * `call` - The call chain to add the request to
+    * `method` - The RPC method name (string or atom)
+    * `params` - List of parameters for the method
+
+  ## Returns
+    * A new `Call` struct with the request added to the chain
+
+  ## Examples
+      call
+      |> Call.add_request("eth_blockNumber", [])
+      |> Call.add_request("eth_getBalance", ["0x742d...", "latest"])
+  """
+  @spec add_request(t(), Types.method(), Types.params()) :: t()
+  def add_request(%__MODULE__{} = call, method, params) do
+    id = Client.generate_id(call.client)
+    request = Request.new(method, params, id)
+    %{call | requests: call.requests ++ [request]}
+  end
+
+  @doc """
+  Returns the list of requests in the call chain.
+
+  ## Parameters
+    * `call` - The call chain to get requests from
+
+  ## Returns
+    * A list of `Request` structs
+
+  ## Examples
+      requests = Call.get_requests(call)
+      # => [
+      #   %Request{method: "eth_blockNumber", params: [], id: 1},
+      #   %Request{method: "eth_getBalance", params: ["0x742d...", "latest"], id: 2}
+      # ]
+  """
+  @spec get_requests(t()) :: [Request.t()]
+  def get_requests(%__MODULE__{} = call), do: call.requests
+
+  @doc """
+  Returns the client associated with this call chain.
+
+  ## Parameters
+    * `call` - The call chain to get the client from
+
+  ## Returns
+    * The `Client` struct associated with the call chain
+
+  ## Examples
+      client = Call.get_client(call)
+      # => %Client{...}
+  """
+  @spec get_client(t()) :: Client.t()
+  def get_client(%__MODULE__{} = call), do: call.client
+end

--- a/lib/exth/rpc/request.ex
+++ b/lib/exth/rpc/request.ex
@@ -19,20 +19,20 @@ defmodule Exth.Rpc.Request do
       }
   """
 
-  alias Exth.Rpc
+  alias Exth.Rpc.Types
 
   @type t :: %__MODULE__{
-          id: Rpc.id(),
-          jsonrpc: Rpc.jsonrpc(),
-          method: Rpc.method(),
-          params: Rpc.params()
+          id: Types.id(),
+          jsonrpc: Types.jsonrpc(),
+          method: Types.method(),
+          params: Types.params()
         }
 
   defstruct [
     :method,
     id: nil,
     params: [],
-    jsonrpc: Rpc.jsonrpc_version()
+    jsonrpc: Types.jsonrpc_version()
   ]
 
   @doc """
@@ -55,7 +55,7 @@ defmodule Exth.Rpc.Request do
       request = Request.new("eth_getBalance", ["0x742d...", "latest"], 1)
       # => %Request{id: 1, method: "eth_getBalance", params: ["0x742d...", "latest"]}
   """
-  @spec new(Rpc.method(), Rpc.params(), Rpc.id() | nil) :: t()
+  @spec new(Types.method(), Types.params(), Types.id() | nil) :: t()
   def new(method, params, id \\ nil) do
     validate_method(method)
     validate_params(params)

--- a/lib/exth/rpc/response.ex
+++ b/lib/exth/rpc/response.ex
@@ -31,7 +31,7 @@ defmodule Exth.Rpc.Response do
       }
   """
 
-  alias Exth.Rpc
+  alias Exth.Rpc.Types
 
   defmodule Success do
     @moduledoc """
@@ -53,14 +53,14 @@ defmodule Exth.Rpc.Response do
     """
 
     @type t :: %__MODULE__{
-            id: Rpc.id(),
-            jsonrpc: Rpc.jsonrpc(),
+            id: Types.id(),
+            jsonrpc: Types.jsonrpc(),
             result: String.t()
           }
     defstruct [
       :id,
       :result,
-      jsonrpc: Rpc.jsonrpc_version()
+      jsonrpc: Types.jsonrpc_version()
     ]
   end
 
@@ -98,8 +98,8 @@ defmodule Exth.Rpc.Response do
     """
 
     @type t :: %__MODULE__{
-            id: Rpc.id(),
-            jsonrpc: Rpc.jsonrpc(),
+            id: Types.id(),
+            jsonrpc: Types.jsonrpc(),
             error: %{
               code: integer(),
               message: String.t(),
@@ -109,16 +109,16 @@ defmodule Exth.Rpc.Response do
     defstruct [
       :id,
       :error,
-      jsonrpc: Rpc.jsonrpc_version()
+      jsonrpc: Types.jsonrpc_version()
     ]
   end
 
   @type t :: Success.t() | Error.t()
 
-  @spec success(Rpc.id(), String.t()) :: Success.t()
+  @spec success(Types.id(), String.t()) :: Success.t()
   def success(id, result) when not is_nil(id), do: %Success{id: id, result: result}
 
-  @spec error(Rpc.id(), integer(), String.t(), any() | nil) :: Error.t()
+  @spec error(Types.id(), integer(), String.t(), any() | nil) :: Error.t()
   def error(id, code, message, data \\ nil) when not is_nil(id) do
     %Error{id: id, error: %{code: code, message: message, data: data}}
   end

--- a/lib/exth/rpc/types.ex
+++ b/lib/exth/rpc/types.ex
@@ -1,0 +1,17 @@
+defmodule Exth.Rpc.Types do
+  @moduledoc """
+  Common types used across the RPC modules.
+  """
+
+  @type id :: pos_integer()
+  @type jsonrpc :: String.t()
+  @type method :: atom() | String.t()
+  @type params :: list(term())
+
+  @jsonrpc_version "2.0"
+
+  @doc """
+  Returns the JSON-RPC protocol version used.
+  """
+  def jsonrpc_version, do: @jsonrpc_version
+end

--- a/test/exth/rpc/call_test.exs
+++ b/test/exth/rpc/call_test.exs
@@ -1,0 +1,83 @@
+defmodule Exth.Rpc.CallTest do
+  use ExUnit.Case, async: true
+
+  alias Exth.Rpc.Call
+  alias Exth.Rpc.Client
+  alias Exth.Rpc.Request
+
+  @rpc_url "http://localhost:8545"
+
+  describe "new/1" do
+    test "creates a new call with the given client" do
+      client = Client.new(:http, rpc_url: @rpc_url)
+      call = Call.new(client)
+
+      assert %Call{client: ^client, requests: []} = call
+    end
+  end
+
+  describe "add_request/3" do
+    test "adds a request to the call chain" do
+      client = Client.new(:http, rpc_url: @rpc_url)
+      call = Call.new(client)
+
+      # Add first request
+      call = Call.add_request(call, "eth_blockNumber", [])
+      assert length(call.requests) == 1
+      [request1] = call.requests
+      assert %Request{method: "eth_blockNumber", params: []} = request1
+      assert is_integer(request1.id)
+
+      # Add second request
+      call = Call.add_request(call, "eth_getBalance", ["0x123", "latest"])
+      assert length(call.requests) == 2
+      [_, request2] = call.requests
+      assert %Request{method: "eth_getBalance", params: ["0x123", "latest"]} = request2
+      assert is_integer(request2.id)
+      assert request2.id != request1.id
+    end
+
+    test "preserves the client when adding requests" do
+      client = Client.new(:http, rpc_url: @rpc_url)
+      call = Call.new(client)
+      call = Call.add_request(call, "eth_blockNumber", [])
+      assert call.client == client
+    end
+  end
+
+  describe "get_requests/1" do
+    test "returns the list of requests in the call chain" do
+      client = Client.new(:http, rpc_url: @rpc_url)
+
+      call =
+        Call.new(client)
+        |> Call.add_request(call, "eth_blockNumber", [])
+        |> Call.add_request(call, "eth_getBalance", ["0x123", "latest"])
+
+      requests = Call.get_requests(call)
+      assert length(requests) == 2
+      [request1, request2] = requests
+
+      assert %Request{method: "eth_blockNumber", params: []} = request1
+      assert %Request{method: "eth_getBalance", params: ["0x123", "latest"]} = request2
+    end
+
+    test "returns an empty list for a new call" do
+      client = Client.new(:http, rpc_url: @rpc_url)
+      call = Call.new(client)
+      assert [] = Call.get_requests(call)
+    end
+  end
+
+  describe "get_client/1" do
+    test "returns the client associated with the call chain" do
+      client = Client.new(:http, rpc_url: @rpc_url)
+      call = Call.new(client)
+      assert ^client = Call.get_client(call)
+
+      # Verify client is still returned after adding requests
+      call = Call.add_request(call, "eth_blockNumber", [])
+      assert ^client = Call.get_client(call)
+    end
+  end
+end

--- a/test/exth/rpc/call_test.exs
+++ b/test/exth/rpc/call_test.exs
@@ -51,8 +51,8 @@ defmodule Exth.Rpc.CallTest do
 
       call =
         Call.new(client)
-        |> Call.add_request(call, "eth_blockNumber", [])
-        |> Call.add_request(call, "eth_getBalance", ["0x123", "latest"])
+        |> Call.add_request("eth_blockNumber", [])
+        |> Call.add_request("eth_getBalance", ["0x123", "latest"])
 
       requests = Call.get_requests(call)
       assert length(requests) == 2


### PR DESCRIPTION
**Why:**

We need a more fluent way to make requests with the RPC client.

**How:**

By returning an `Rpc.Call` struct when creating a new request and passing it to other requests.
We can then use this `Rpc.Call` as the argument to the `Client.send/1` function.

An example of a single request would be:
```elixir
client 
|> Rpc.request("eth_blockNumber", []) 
|> Rpc.send()
```

A batch request would be something like:
```elixir
client 
|> Rpc.request("eth_blockNumber", []) 
|> Rpc.request("eth_getBalance", ["0x742d...", "latest"])
|> Rpc.send()
```

If we still want to make a raw request for a specific reason, we can do something like:
```elixir
request = Rpc.raw_request("eth_blockNumber", [])
Rpc.send(request, client)
# or
Rpc.send(client, request)
```

This offers a simpler and more fluent api for making requests.