### PR TITLE
Fix - :otp_app is not require in the Provider

### DIFF
--- a/lib/exth/provider.ex
+++ b/lib/exth/provider.ex
@@ -172,7 +172,7 @@ defmodule Exth.Provider do
       @type rpc_response :: {:ok, term()} | {:error, term()}
 
       @default_block_tag "latest"
-      @provider_app Keyword.fetch!(opts, :otp_app)
+      @provider_app Keyword.get(opts, :otp_app)
       @provider_key __MODULE__
       @provider_inline_opts opts
 


### PR DESCRIPTION
**Why:**

In `Exth.Provider` we fetched the module `:otp_app` with `Keyword.fetch!/2`.
The thing is that if the module didn't have this option, it would raise. But this is not desired because we use `:otp_app` to later fetch the app config, which might not be required if all config is set as options in the provider.

**How:**

By replacing `Keyword.fetch!/2` with `Keyword.get/3`, which defaults to `nil` when there's no `:otp_app`.