### PR TITLE
Transport layer is only responsible for sending/receiving requests

### DIFF
--- a/lib/exth/rpc/client.ex
+++ b/lib/exth/rpc/client.ex
@@ -184,8 +184,6 @@ defmodule Exth.Rpc.Client do
     end
   end
 
-  defp validate_unique_ids(request) when is_map(request), do: :ok
-
   defp validate_unique_ids(requests) when is_list(requests) do
     existing_ids = requests |> Enum.map(& &1.id) |> Enum.reject(&is_nil/1)
 
@@ -194,14 +192,6 @@ defmodule Exth.Rpc.Client do
     else
       {:error, :duplicate_ids}
     end
-  end
-
-  defp assign_missing_ids(client, %Request{id: nil} = request) do
-    %Request{request | id: generate_id(client)}
-  end
-
-  defp assign_missing_ids(_client, %Request{} = request) do
-    request
   end
 
   defp assign_missing_ids(client, requests) when is_list(requests) do

--- a/lib/exth/rpc/client.ex
+++ b/lib/exth/rpc/client.ex
@@ -97,6 +97,7 @@ defmodule Exth.Rpc.Client do
   """
   alias Exth.Rpc.Call
   alias Exth.Rpc.Request
+  alias Exth.Rpc.Response
   alias Exth.Rpc.Types
   alias Exth.Transport
   alias Exth.Transport.Transportable
@@ -139,28 +140,21 @@ defmodule Exth.Rpc.Client do
   def send(%Call{} = call) do
     client = Call.get_client(call)
     requests = Call.get_requests(call)
+    do_send(client, requests)
 
     case requests do
-      [request] -> send_single(client, request)
-      requests -> send_batch(client, requests)
+      [request] -> do_send(client, request)
+      requests -> do_send(client, requests)
     end
   end
 
   @spec send(send_argument_type(), send_argument_type()) :: send_response_type()
-  def send(%__MODULE__{} = client, %Request{} = request) do
-    send_single(client, request)
+  def send(%__MODULE__{} = client, request) do
+    do_send(client, request)
   end
 
-  def send(%Request{} = request, %__MODULE__{} = client) do
-    send_single(client, request)
-  end
-
-  def send(%__MODULE__{} = client, requests) when is_list(requests) do
-    send_batch(client, requests)
-  end
-
-  def send(requests, %__MODULE__{} = client) when is_list(requests) do
-    send_batch(client, requests)
+  def send(request, %__MODULE__{} = client) do
+    do_send(client, request)
   end
 
   @spec generate_id(t()) :: non_neg_integer()
@@ -172,27 +166,27 @@ defmodule Exth.Rpc.Client do
   ### Private Functions
   ###
 
-  defp send_single(%__MODULE__{} = client, %Request{} = request) do
-    request =
-      if is_nil(request.id) do
-        %Request{request | id: generate_id(client)}
-      else
-        request
-      end
-
-    Transport.call(client.transport, request)
-  end
-
-  defp send_batch(%__MODULE__{}, []), do: {:ok, []}
-
-  defp send_batch(%__MODULE__{} = client, requests) do
-    with :ok <- validate_unique_ids(requests) do
-      requests = assign_missing_ids(client, requests)
-      Transport.call(client.transport, requests)
+  defp do_send(%__MODULE__{} = client, %Request{} = request) do
+    case do_send(client, [request]) do
+      {:ok, [result]} -> {:ok, result}
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp validate_unique_ids(requests) do
+  defp do_send(%__MODULE__{}, []), do: {:ok, []}
+
+  defp do_send(%__MODULE__{} = client, requests) when is_list(requests) do
+    with :ok <- validate_unique_ids(requests),
+         requests <- assign_missing_ids(client, requests),
+         {:ok, encoded_requests} <- Request.serialize(requests),
+         {:ok, encoded_response} <- Transport.call(client.transport, encoded_requests) do
+      Response.deserialize(encoded_response)
+    end
+  end
+
+  defp validate_unique_ids(request) when is_map(request), do: :ok
+
+  defp validate_unique_ids(requests) when is_list(requests) do
     existing_ids = requests |> Enum.map(& &1.id) |> Enum.reject(&is_nil/1)
 
     if length(existing_ids) == length(Enum.uniq(existing_ids)) do
@@ -202,7 +196,15 @@ defmodule Exth.Rpc.Client do
     end
   end
 
-  defp assign_missing_ids(client, requests) do
+  defp assign_missing_ids(client, %Request{id: nil} = request) do
+    %Request{request | id: generate_id(client)}
+  end
+
+  defp assign_missing_ids(_client, %Request{} = request) do
+    request
+  end
+
+  defp assign_missing_ids(client, requests) when is_list(requests) do
     existing_ids = MapSet.new(requests, & &1.id)
 
     Enum.map(requests, fn request ->

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -34,7 +34,6 @@ defmodule Exth.Transport do
 
       # Make requests
       {:ok, response} = Transport.call(transport, request)
-      {:ok, responses} = Transport.call(transport, [request1, request2])
 
   ## Configuration
 
@@ -83,7 +82,7 @@ defmodule Exth.Transport do
 
   The module uses consistent error handling:
 
-    * `{:ok, response}` - Successful request with decoded response
+    * `{:ok, response}` - Successful request with response
     * `{:ok, responses}` - Successful batch request with responses
     * `{:error, reason}` - Request failed with detailed reason
 
@@ -106,8 +105,6 @@ defmodule Exth.Transport do
   """
 
   alias __MODULE__.Transportable
-  alias Exth.Rpc.Request
-  alias Exth.Rpc.Response
 
   @typedoc """
   Supported transport types:
@@ -162,19 +159,18 @@ defmodule Exth.Transport do
   end
 
   @type error_reason :: Exception.t() | String.t() | term()
-  @type call_response :: {:ok, Response.t() | [Response.t()]} | {:error, error_reason()}
 
   @doc """
   Makes a request using the configured transport.
 
   ## Parameters
     * `transportable` - The configured transport instance
-    * `request` - The JSON-RPC request to send
+    * `request` - The JSON-RPC encoded request to send
 
   ## Returns
-    * `{:ok, response}` - Successful request with decoded response
+    * `{:ok, response}` - Successful request with encoded response
     * `{:error, reason}` - Request failed with error reason
   """
-  @spec call(Transportable.t(), Request.t() | [Request.t()]) :: call_response()
-  def call(transportable, request), do: Transportable.call(transportable, request)
+  @spec call(Transportable.t(), String.t()) :: {:ok, String.t()} | {:error, error_reason()}
+  def call(transportable, encoded_request), do: Transportable.call(transportable, encoded_request)
 end

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -159,6 +159,7 @@ defmodule Exth.Transport do
   end
 
   @type error_reason :: Exception.t() | String.t() | term()
+  @type call_response :: {:ok, String.t()} | {:error, error_reason()}
 
   @doc """
   Makes a request using the configured transport.
@@ -171,6 +172,6 @@ defmodule Exth.Transport do
     * `{:ok, response}` - Successful request with encoded response
     * `{:error, reason}` - Request failed with error reason
   """
-  @spec call(Transportable.t(), String.t()) :: {:ok, String.t()} | {:error, error_reason()}
+  @spec call(Transportable.t(), String.t()) :: call_response()
   def call(transportable, encoded_request), do: Transportable.call(transportable, encoded_request)
 end

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -158,8 +158,7 @@ defmodule Exth.Transport do
     raise(ArgumentError, "invalid transport type: #{inspect(type)}")
   end
 
-  @type error_reason :: Exception.t() | String.t() | term()
-  @type call_response :: {:ok, String.t()} | {:error, error_reason()}
+  @type call_response :: Transportable.call_response()
 
   @doc """
   Makes a request using the configured transport.

--- a/lib/exth/transport/http.ex
+++ b/lib/exth/transport/http.ex
@@ -84,7 +84,6 @@ defmodule Exth.Transport.Http do
     [
       {Tesla.Middleware.BaseUrl, config[:rpc_url]},
       {Tesla.Middleware.Headers, build_headers(config[:headers])},
-      {Tesla.Middleware.JSON, encode: &Request.serialize/1, decode: &Response.deserialize/1},
       {Tesla.Middleware.Timeout, timeout: config[:timeout]}
     ]
   end

--- a/lib/exth/transport/http.ex
+++ b/lib/exth/transport/http.ex
@@ -16,9 +16,6 @@ defmodule Exth.Transport.Http do
       {:ok, response} = Transportable.call(transport, request)
   """
 
-  alias Exth.Rpc.Request
-  alias Exth.Rpc.Response
-
   @typedoc "HTTP transport configuration"
   @type t :: %__MODULE__{
           client: Tesla.Client.t()
@@ -34,12 +31,11 @@ defmodule Exth.Transport.Http do
   Makes an HTTP request to the JSON-RPC endpoint.
 
   Returns:
-    * `{:ok, responses}` - Successful request with decoded response or responses
+    * `{:ok, response}` - Successful request with encoded response
     * `{:error, {:http_error, status}}` - HTTP error response
     * `{:error, reason}` - Other errors (network, timeout, etc)
   """
-  @spec call(t(), Request.t() | [Request.t()]) ::
-          {:ok, Response.t() | [Response.t()]} | {:error, term()}
+  @spec call(t(), String.t()) :: {:ok, String.t()} | {:error, term()}
   def call(%__MODULE__{client: client}, request) do
     case Tesla.post(client, "", request) do
       {:ok, %Tesla.Env{status: 200, body: response}} -> {:ok, response}

--- a/lib/exth/transport/transportable.ex
+++ b/lib/exth/transport/transportable.ex
@@ -31,9 +31,6 @@ defprotocol Exth.Transport.Transportable do
       {:ok, response} = Transportable.call(transport, request)
   """
 
-  alias Exth.Rpc.Request
-  alias Exth.Rpc.Response
-
   @doc """
   Creates a new transport instance with the given options.
 
@@ -56,34 +53,14 @@ defprotocol Exth.Transport.Transportable do
   @doc """
   Makes a request using the configured transport.
 
-  Supports both single requests and batch requests (arrays of requests).
-
   ## Parameters
     * `transport` - The configured transport struct
-    * `request` - Single request or list of requests (Request.t() | [Request.t()])
+    * `request` - Encoded JSON-RPC request
 
   ## Returns
-    * `{:ok, response}` - Successful request with decoded response (Response.t())
-    * `{:ok, responses}` - Successful batch request with decoded responses ([Response.t()])
+    * `{:ok, response}` - Successful request with encoded response
     * `{:error, reason}` - Request failed with error reason (Exception.t() or map())
-
-  ## Examples
-
-      # Single request
-      {:ok, response} = Transportable.call(transport, %Request{
-        jsonrpc: "2.0",
-        method: "eth_blockNumber",
-        params: [],
-        id: 1
-      })
-
-      # Batch request
-      {:ok, responses} = Transportable.call(transport, [
-        %Request{method: "eth_blockNumber", params: [], id: 1},
-        %Request{method: "eth_getBalance", params: ["0x123...", "latest"], id: 2}
-      ])
   """
-  @spec call(t, Request.t() | [Request.t()]) ::
-          {:ok, Response.t() | [Response.t()]} | {:error, Exception.t()}
+  @spec call(t, String.t()) :: {:ok, String.t()} | {:error, Exception.t()}
   def call(transport, request)
 end

--- a/lib/exth/transport/transportable.ex
+++ b/lib/exth/transport/transportable.ex
@@ -50,6 +50,9 @@ defprotocol Exth.Transport.Transportable do
   @spec new(t, keyword()) :: t
   def new(transport, opts)
 
+  @type error_reason :: Exception.t() | String.t() | term()
+  @type call_response :: {:ok, String.t()} | {:error, error_reason()}
+
   @doc """
   Makes a request using the configured transport.
 
@@ -61,6 +64,6 @@ defprotocol Exth.Transport.Transportable do
     * `{:ok, response}` - Successful request with encoded response
     * `{:error, reason}` - Request failed with error reason (Exception.t() or map())
   """
-  @spec call(t, String.t()) :: {:ok, String.t()} | {:error, Exception.t()}
+  @spec call(t, String.t()) :: call_response()
   def call(transport, request)
 end

--- a/test/exth/transport/transportable_test.exs
+++ b/test/exth/transport/transportable_test.exs
@@ -13,14 +13,14 @@ defmodule Exth.Transport.TransportableTest do
   describe "protocol requirements" do
     test "raises Protocol.UndefinedError when protocol is not implemented" do
       transport = %InvalidTransport{}
-      request = Request.new("eth_blockNumber", [], 1)
+      encoded_request = Request.new("eth_blockNumber", [], 1) |> Request.serialize()
 
       assert_raise Protocol.UndefinedError, @error_message, fn ->
         Transportable.new(transport, [])
       end
 
       assert_raise Protocol.UndefinedError, @error_message, fn ->
-        Transportable.call(transport, request)
+        Transportable.call(transport, encoded_request)
       end
     end
   end

--- a/test/support/stubs/test_transport.ex
+++ b/test/support/stubs/test_transport.ex
@@ -17,14 +17,21 @@ end
 defimpl Exth.Transport.Transportable, for: Exth.TestTransport do
   def new(_transport, opts), do: %Exth.TestTransport{config: opts}
 
-  def call(_transport, %{method: method, id: id} = _request) do
+  def call(transport, encoded_request) do
+    decoded_request = JSON.decode!(encoded_request)
+    request_data = for {k, v} <- decoded_request, into: %{}, do: {String.to_atom(k), v}
+    request = struct(Exth.Rpc.Request, request_data)
+    do_call(transport, request)
+  end
+
+  defp do_call(_transport, %{method: method, id: id} = _request) do
     case Map.get(Exth.TestTransport.get_known_methods(), method) do
-      nil -> {:ok, Exth.Rpc.Response.error(id, -32_601, "Method not found")}
-      result -> {:ok, Exth.Rpc.Response.success(id, result)}
+      nil -> {:ok, JSON.encode!(%{id: id, error: %{code: -32_601, message: "Method not found"}})}
+      result -> {:ok, JSON.encode!(%{id: id, result: result})}
     end
   end
 
-  def call(transport, requests) do
+  defp do_call(transport, requests) do
     requests
     |> Enum.map(&call(transport, &1))
     |> Enum.map(fn {:ok, response} -> response end)


### PR DESCRIPTION
**Why:**

We want the core parts of `Exth` to have clear responsibilities and to be as minimal as possible.
So far, the `Transport` layer is responsible for sending/receiving requests as well as serializing/deserializing `Request`s and `Response`s.
The last part should not be within the Transport scope.

**How:**

By moving encoding/decoding to `Client` and making `Transport` layer simpler.
As a consequence, we needed to improve `Client.send/2` logic.