### PR TITLE
Add InnerClient as foundation for Async Transports

### DIFF
--- a/lib/exth/rpc/inner_client.ex
+++ b/lib/exth/rpc/inner_client.ex
@@ -1,5 +1,60 @@
 defmodule Exth.Rpc.InnerClient do
-  @moduledoc false
+  @moduledoc """
+  A GenServer that manages asynchronous transport for JSON-RPC requests.
+
+  This module provides a persistent connection manager for asynchronous transports
+  (like WebSocket), handling request/response correlation and connection state.
+  It uses ETS tables to track pending requests and their corresponding callers.
+
+  ## Features
+
+    * Request/response correlation using ETS tables
+    * Automatic request ID generation and tracking
+    * Batch request support
+    * Connection state management
+    * Error handling and timeout management
+    * Support for any asynchronous transport implementation
+
+  ## Usage
+
+      # Create a new inner client
+      {:ok, client} = InnerClient.new()
+
+      # Set the transport
+      :ok = InnerClient.set_transport(client, transport)
+
+      # Send a request
+      {:ok, response} = InnerClient.call(client, request)
+
+  ## Request/Response Flow
+
+  1. Client sends a request through `call/2`
+  2. Request ID is stored in ETS table with caller's PID
+  3. Request is sent through transport
+  4. Response is received and matched with request
+  5. Response is sent back to caller
+  6. Request entry is removed from ETS table
+
+  ## Error Handling
+
+  The client handles several error cases:
+    * Deserialization errors
+    * Orphaned responses
+    * Timeouts
+    * Transport errors
+
+  ## Timeouts
+
+  The default timeout for operations is 5000ms. This can be overridden
+  by passing a timeout value to `call/3`.
+
+  ## Transport Implementation
+
+  Any transport implementation can be used with the InnerClient as long as it:
+    * Implements the `Exth.Transport.Transportable` protocol
+    * Handles asynchronous communication
+    * Sends responses back to the InnerClient process using `{:response, encoded_response}` messages
+  """
 
   use GenServer
 
@@ -9,19 +64,62 @@ defmodule Exth.Rpc.InnerClient do
   alias Exth.Transport.Transportable
 
   @type request_id :: pos_integer() | String.t()
+  @type state :: %{
+          transport: Transportable.t() | nil,
+          request_table: :ets.table()
+        }
 
   @call_timeout 5_000
 
   # Public API
 
+  @doc """
+  Creates a new InnerClient process.
+
+  ## Returns
+    * `{:ok, pid()}` - Successfully started client
+    * `{:error, term()}` - Failed to start client
+
+  ## Example
+      {:ok, client} = InnerClient.new()
+  """
   @spec new() :: {:ok, pid()} | {:error, term()}
   def new, do: GenServer.start_link(__MODULE__, %{})
 
+  @doc """
+  Sets the transport for the client.
+
+  ## Parameters
+    * `client` - The client PID
+    * `transport` - The transport to use (must implement Transportable protocol)
+
+  ## Returns
+    * `:ok` - Successfully set transport
+    * `{:error, term()}` - Failed to set transport
+
+  ## Example
+      :ok = InnerClient.set_transport(client, transport)
+  """
   @spec set_transport(pid(), Transportable.t()) :: :ok | {:error, term()}
   def set_transport(client, transport) do
     GenServer.call(client, {:set_transport, transport}, @call_timeout)
   end
 
+  @doc """
+  Sends a request through the client and waits for a response.
+
+  ## Parameters
+    * `client` - The client PID
+    * `requests` - The request(s) to send
+    * `timeout` - Optional timeout in milliseconds (default: 5000)
+
+  ## Returns
+    * `{:ok, response}` - Successful response
+    * `{:error, term()}` - Request failed
+
+  ## Example
+      {:ok, response} = InnerClient.call(client, request)
+  """
   @spec call(pid(), [Request.t()]) :: {:ok, [Response.t()]} | {:error, term()}
   def call(client, requests, timeout \\ @call_timeout) do
     GenServer.call(client, {:send, requests}, timeout)
@@ -79,12 +177,15 @@ defmodule Exth.Rpc.InnerClient do
 
   # Private functions
 
+  @doc false
   defp get_request_id(%{id: id}), do: id
   defp get_request_id(requests), do: Enum.map_join(requests, "_", &get_request_id/1)
 
+  @doc false
   defp get_response_id(%{id: id}), do: id
   defp get_response_id(responses), do: Enum.map_join(responses, "_", &get_response_id/1)
 
+  @doc false
   defp send_request(transport, requests) do
     {:ok, encoded_request} = Request.serialize(requests)
     Transport.call(transport, encoded_request)

--- a/lib/exth/rpc/inner_client.ex
+++ b/lib/exth/rpc/inner_client.ex
@@ -1,0 +1,83 @@
+defmodule Exth.Rpc.InnerClient do
+  @moduledoc false
+
+  use GenServer
+
+  alias Exth.Rpc.Request
+  alias Exth.Rpc.Response
+  alias Exth.Transport
+  alias Exth.Transport.Transportable
+
+  @type request_id :: pos_integer() | String.t()
+
+  @call_timeout 5_000
+
+  # Public API
+
+  @spec new() :: {:ok, pid()} | {:error, term()}
+  def new, do: GenServer.start_link(__MODULE__, %{})
+
+  @spec set_transport(pid(), Transportable.t()) :: :ok | {:error, term()}
+  def set_transport(client, transport) do
+    GenServer.call(client, {:set_transport, transport}, @call_timeout)
+  end
+
+  @spec call(pid(), Request.t() | [Request.t()]) :: {:ok, Response.t()} | {:error, term()}
+  def call(client, request, timeout \\ @call_timeout) do
+    GenServer.call(client, {:send, request}, timeout)
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(_state) do
+    table_name = :crypto.strong_rand_bytes(20) |> Base.encode64() |> String.to_atom()
+    table = :ets.new(table_name, [:named_table, :set, :protected])
+
+    state = %{
+      transport: nil,
+      request_table: table
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:send, %Request{} = request}, from, state) do
+    :ets.insert(state.request_table, {request.id, from})
+    send_request(state.transport, request)
+    {:noreply, state}
+  end
+
+  def handle_call({:set_transport, transport}, _from, state) do
+    {:reply, :ok, %{state | transport: transport}}
+  end
+
+  @impl true
+  def handle_info({:response, encoded_response}, state) do
+    case Response.deserialize(encoded_response) do
+      {:ok, response} ->
+        case :ets.lookup(state.request_table, response.id) do
+          [{id, from}] ->
+            :ets.delete(state.request_table, id)
+            GenServer.reply(from, {:ok, response})
+            {:noreply, state}
+
+          [] ->
+            # when there are no requests for the response, weird but possible?
+            {:noreply, state}
+        end
+
+      {:error, _reason} ->
+        # when deserialization fails, otherwise the process will crash
+        {:noreply, state}
+    end
+  end
+
+  # Private functions
+
+  defp send_request(transport, requests) do
+    {:ok, encoded_request} = Request.serialize(requests)
+    Transport.call(transport, encoded_request)
+  end
+end

--- a/lib/exth/rpc/inner_client.ex
+++ b/lib/exth/rpc/inner_client.ex
@@ -79,11 +79,11 @@ defmodule Exth.Rpc.InnerClient do
 
   # Private functions
 
-  defp get_request_id([%Request{} = request]), do: request.id
-  defp get_request_id(requests), do: Enum.map_join(requests, "_", & &1["id"])
+  defp get_request_id(%{id: id}), do: id
+  defp get_request_id(requests), do: Enum.map_join(requests, "_", &get_request_id/1)
 
-  defp get_response_id([%{id: id}]), do: id
-  defp get_response_id(responses), do: Enum.map_join(responses, "_", & &1["id"])
+  defp get_response_id(%{id: id}), do: id
+  defp get_response_id(responses), do: Enum.map_join(responses, "_", &get_response_id/1)
 
   defp send_request(transport, requests) do
     {:ok, encoded_request} = Request.serialize(requests)

--- a/lib/exth/rpc/response.ex
+++ b/lib/exth/rpc/response.ex
@@ -134,7 +134,7 @@ defmodule Exth.Rpc.Response do
       iex> Exth.Rpc.Response.deserialize(~s({"jsonrpc": "2.0", "error": {"code": -32_601, "message": "Method not found"}, "id": 1}))
       {:ok, %Exth.Rpc.Response.Error{id: 1, error: %{code: -32_601, message: "Method not found"}}}
   """
-  @spec deserialize(String.t()) :: {:ok, t() | [t()]} | {:error, Exception.t()}
+  @spec deserialize(String.t()) :: {:ok, t() | [t()]} | {:error, term()}
   def deserialize(json) when is_binary(json) do
     with {:ok, response} <- JSON.decode(json) do
       do_decode_response(response)

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -111,7 +111,7 @@ defmodule Exth.Transport do
   * `:http` - HTTP/HTTPS transport
   * `:custom` - Custom transport implementation
   """
-  @type type :: :custom | :http
+  @type type :: :custom | :http | :websocket
 
   @typedoc """
   Transport configuration options.
@@ -151,6 +151,10 @@ defmodule Exth.Transport do
   defp get_transport_module(:http, _opts), do: __MODULE__.Http
 
   defp get_transport_module(:custom, opts) do
+    opts[:module] || raise ArgumentError, "missing required option :module"
+  end
+
+  defp get_transport_module(:websocket, opts) do
     opts[:module] || raise ArgumentError, "missing required option :module"
   end
 

--- a/test/exth/rpc/inner_client_test.exs
+++ b/test/exth/rpc/inner_client_test.exs
@@ -30,8 +30,8 @@ defmodule Exth.Rpc.InnerClientTest do
     test "sends a request and receives a response", %{client: client, transport: transport} do
       :ok = InnerClient.set_transport(client, transport)
 
-      request = %Request{id: 1, method: "eth_blockNumber", params: []}
-      response = %{id: 1, result: "test"}
+      request = [%Request{id: 1, method: "eth_blockNumber", params: []}]
+      response = [%{id: 1, result: "test"}]
 
       # Start a process to send the response
       spawn(fn ->
@@ -39,13 +39,13 @@ defmodule Exth.Rpc.InnerClientTest do
         send(client, {:response, Jason.encode!(response)})
       end)
 
-      assert {:ok, %Response.Success{id: 1, result: "test"}} = InnerClient.call(client, request)
+      assert {:ok, [%Response.Success{id: 1, result: "test"}]} = InnerClient.call(client, request)
     end
 
     test "handles deserialization errors", %{client: client, transport: transport} do
       :ok = InnerClient.set_transport(client, transport)
 
-      request = %Request{id: 1, method: "test", params: []}
+      request = [%Request{id: 1, method: "test", params: []}]
 
       # Start a process to send an invalid response
       spawn(fn ->

--- a/test/exth/rpc/inner_client_test.exs
+++ b/test/exth/rpc/inner_client_test.exs
@@ -1,0 +1,73 @@
+defmodule Exth.Rpc.InnerClientTest do
+  use ExUnit.Case, async: true
+
+  alias Exth.AsyncTestTransport
+  alias Exth.Rpc.InnerClient
+  alias Exth.Rpc.Request
+  alias Exth.Rpc.Response
+  alias Exth.Transport
+
+  setup do
+    transport = Transport.new(:custom, rpc_url: "https://example.com", module: AsyncTestTransport)
+    {:ok, client} = InnerClient.new()
+    %{client: client, transport: transport}
+  end
+
+  describe "new/0" do
+    test "creates a new InnerClient process" do
+      assert {:ok, pid} = InnerClient.new()
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "set_transport/2" do
+    test "sets the transport for the client", %{client: client, transport: transport} do
+      assert :ok = InnerClient.set_transport(client, transport)
+    end
+  end
+
+  describe "call/3" do
+    test "sends a request and receives a response", %{client: client, transport: transport} do
+      :ok = InnerClient.set_transport(client, transport)
+
+      request = %Request{id: 1, method: "eth_blockNumber", params: []}
+      response = %{id: 1, result: "test"}
+
+      # Start a process to send the response
+      spawn(fn ->
+        Process.sleep(10)
+        send(client, {:response, Jason.encode!(response)})
+      end)
+
+      assert {:ok, %Response.Success{id: 1, result: "test"}} = InnerClient.call(client, request)
+    end
+
+    test "handles deserialization errors", %{client: client, transport: transport} do
+      :ok = InnerClient.set_transport(client, transport)
+
+      request = %Request{id: 1, method: "test", params: []}
+
+      # Start a process to send an invalid response
+      spawn(fn ->
+        Process.sleep(10)
+        send(client, {:response, "invalid json"})
+      end)
+
+      timeout_ms = 1000
+
+      assert catch_exit(InnerClient.call(client, request, timeout_ms)) ==
+               {:timeout, {GenServer, :call, [client, {:send, request}, timeout_ms]}}
+    end
+
+    test "handles orphaned responses", %{client: client, transport: transport} do
+      :ok = InnerClient.set_transport(client, transport)
+
+      # Send a response without a matching request
+      response = %{id: 999, result: "test"}
+      send(client, {:response, Jason.encode!(response)})
+
+      # The process should not crash
+      assert Process.alive?(client)
+    end
+  end
+end

--- a/test/support/stubs/async_test_transport.ex
+++ b/test/support/stubs/async_test_transport.ex
@@ -1,0 +1,11 @@
+defmodule Exth.AsyncTestTransport do
+  @moduledoc false
+
+  defstruct [:config]
+
+  defimpl Exth.Transport.Transportable do
+    def new(_transport, opts \\ []), do: %Exth.AsyncTestTransport{config: opts}
+
+    def call(_transport, _encoded_request), do: :ok
+  end
+end


### PR DESCRIPTION
**Why:**

Soon we'll add Websocket support, which is an async transport.
Async transports have a peculiarity that makes them very different from sync transports like HTTP. Websockets are bi-directional, and we can use the same connection to serve concurrent requests, meaning that the request management is complex, and we need to keep a map of the requests to match the received responses later.

**How:**

By adding the concept of an `InnerClient`, which is a Genserver responsible for matching requests and responses.
The `InnerClient` holds an `ETS` table where its keys are the request IDs, and the values are the PIDs of the processes waiting on a response for those specific requests.