### PR TITLE
Add support for subscriptions over Websockets

### DIFF
--- a/lib/exth/rpc/message_handler.ex
+++ b/lib/exth/rpc/message_handler.ex
@@ -167,7 +167,7 @@ defmodule Exth.Rpc.MessageHandler do
   # Private functions
 
   @doc false
-  defp get_correlation_id(%{id: id}), do: id
+  defp get_correlation_id(%{id: id}), do: to_string(id)
   defp get_correlation_id(requests), do: Enum.map_join(requests, "_", &get_correlation_id/1)
 
   @doc false


### PR DESCRIPTION
**Why:**

Unlike HTTP, with WebSockets, we don't need to continuously make requests when we want specific information. WebSockets maintain a network connection, so we can listen for changes.
When connected through a WebSocket, we may use two additional methods: `eth_subscribe` and `eth_unsubscribe`. These methods will allow us to listen for particular events and be notified immediately.

**How:**

By making the distinction between normal RPCs and `eth_subscribe` and `eth_unsubscribe` in the `MessageHandler`.
After receiving a subscription response, we register the subscription ID under the caller process, and then we send `SubscriptionEvents` to this process.

Solves: #66 