### PR TITLE
Fixes user-agent

### DIFF
--- a/lib/exth/transport/http.ex
+++ b/lib/exth/transport/http.ex
@@ -25,7 +25,7 @@ defmodule Exth.Transport.Http do
 
   @adapter Tesla.Adapter.Mint
   @default_timeout 30_000
-  @user_agent "#{Application.spec(:exth, :description)}/#{Application.spec(:exth, :vsn)}"
+  @user_agent "#{Application.spec(:exth, :name)}/#{Application.spec(:exth, :vsn)}"
 
   @doc """
   Makes an HTTP request to the JSON-RPC endpoint.


### PR DESCRIPTION
getting this error locally:

```
{
              :error,
              %Mint.HTTPError{
                module: Mint.HTTP1,
                reason: {:invalid_header_value, "user-agent", "Exth is an Elixir client for interacting with EVM-compatible blockchain nodes\nvia JSON-RPC. It provides a robust interface for making Ethereum RPC calls.\n/0.2.2"},
                __exception__: true
              }
            }
```

for some reason doesn't happen on my CI, but spaces in user-agent seem to be a problem