### PR TITLE
Fix WebSocket test flakiness caused by Registry name conflicts

### DIFF
--- a/test/exth/rpc/client_test.exs
+++ b/test/exth/rpc/client_test.exs
@@ -397,6 +397,13 @@ defmodule Exth.Rpc.ClientTest do
   describe "send/2 with WebSocket transport" do
     setup do
       client = Client.new(:websocket, rpc_url: @valid_url, module: AsyncTestTransport)
+
+      on_exit(fn ->
+        if pid = Process.whereis(client.handler) do
+          Process.exit(pid, :normal)
+        end
+      end)
+
       {:ok, client: client}
     end
 


### PR DESCRIPTION
**Why:**

WebSocket-related tests were intermittently failing with the error `{:error, {:already_started, #PID<...>}}`. This occurred because:

- The `MessageHandler` creates a Registry for each WebSocket connection
- Tests were running in parallel (`async: true`)
- The Registry wasn't being properly cleaned up between tests
- This led to name conflicts when a new test tried to create a Registry with the same name as one from a previous test

**How:**

By implementing `on_exit` callback that cleans up the Registry when the test finishes.
This ensures that:
- Each test gets a fresh Registry
- The Registry is properly cleaned up after each test
- No conflicts between parallel test runs