### PR TITLE
Untrack .iex.exs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ exth-*.tar
 # dialyzer
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+
+# local env
+.iex.exs


### PR DESCRIPTION
**Why:**

`iex.exs` is used for local dev mostly, we don't need to track it.

**How:**

By untrack it.