### PR TITLE
Add Supervision Tree for Transport layer

### DIFF
--- a/lib/exth/application.ex
+++ b/lib/exth/application.ex
@@ -5,7 +5,10 @@ defmodule Exth.Application do
 
   @impl true
   def start(_type, _args) do
-    children = []
+    children = [
+      Exth.Transport.Supervisor
+    ]
+
     opts = [strategy: :one_for_one, name: Exth.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -126,10 +126,10 @@ defmodule Exth.Transport do
 
   <pre class="mermaid">
     flowchart TD
-      A["Exth.Supervisor :one_for_one"] --> B["Transport.Supervisor :one_for_one"]
-      B --> C["Transport.Registry"]
-      B --> D["Transport.Websocket.DynamicSupervisor :one_for_one"]
-      C -.registers.- E["Websocket"]
+      A["Exth.Supervisor :one_for_one"] --> B["Exth.Transport.Supervisor :one_for_one"]
+      B --> C["Exth.Transport.Registry"]
+      B --> D["Exth.Transport.Websocket.DynamicSupervisor :one_for_one"]
+      C -.registers.- E["Exth.Transport.Websocket"]
       D --> E
 
       E@{ shape: procs}

--- a/lib/exth/transport/registry.ex
+++ b/lib/exth/transport/registry.ex
@@ -1,14 +1,17 @@
 defmodule Exth.Transport.Registry do
   @moduledoc false
 
+  @spec start_link() :: {:ok, pid()} | {:error, term()}
   def start_link do
     Registry.start_link(keys: :unique, name: __MODULE__)
   end
 
+  @spec via_tuple(any()) :: {:via, Registry, {__MODULE__, any()}}
   def via_tuple(key) do
     {:via, Registry, {__MODULE__, key}}
   end
 
+  @spec child_spec(any()) :: Supervisor.child_spec()
   def child_spec(_opts) do
     Supervisor.child_spec(Registry, id: __MODULE__, start: {__MODULE__, :start_link, []})
   end

--- a/lib/exth/transport/registry.ex
+++ b/lib/exth/transport/registry.ex
@@ -1,0 +1,15 @@
+defmodule Exth.Transport.Registry do
+  @moduledoc false
+
+  def start_link do
+    Registry.start_link(keys: :unique, name: __MODULE__)
+  end
+
+  def via_tuple(key) do
+    {:via, Registry, {__MODULE__, key}}
+  end
+
+  def child_spec(_opts) do
+    Supervisor.child_spec(Registry, id: __MODULE__, start: {__MODULE__, :start_link, []})
+  end
+end

--- a/lib/exth/transport/supervisor.ex
+++ b/lib/exth/transport/supervisor.ex
@@ -11,7 +11,8 @@ defmodule Exth.Transport.Supervisor do
 
   def init(_opts) do
     children = [
-      Transport.Registry
+      Transport.Registry,
+      Transport.Websocket.DynamicSupervisor
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/exth/transport/supervisor.ex
+++ b/lib/exth/transport/supervisor.ex
@@ -1,0 +1,14 @@
+defmodule Exth.Transport.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(_opts) do
+    children = []
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/exth/transport/supervisor.ex
+++ b/lib/exth/transport/supervisor.ex
@@ -3,12 +3,17 @@ defmodule Exth.Transport.Supervisor do
 
   use Supervisor
 
+  alias Exth.Transport
+
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   def init(_opts) do
-    children = []
+    children = [
+      Transport.Registry
+    ]
+
     Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/exth/transport/websocket/dynamic_supervisor.ex
+++ b/lib/exth/transport/websocket/dynamic_supervisor.ex
@@ -1,0 +1,25 @@
+defmodule Exth.Transport.Websocket.DynamicSupervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  def start_link do
+    DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def child_spec(_opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []},
+      type: :supervisor
+    }
+  end
+
+  def start_websocket(websocket_spec) do
+    DynamicSupervisor.start_child(__MODULE__, websocket_spec)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -84,9 +84,47 @@ defmodule Exth.MixProject do
         Exth.Provider,
         Exth.Rpc,
         Exth.Transport
-      ]
+      ],
+      before_closing_body_tag: &before_closing_body_tag/1
     ]
   end
+
+  defp before_closing_body_tag(:html) do
+    """
+    <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    </script>
+    <script>
+    let initialized = false;
+
+    window.addEventListener("exdoc:loaded", () => {
+    if (!initialized) {
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: document.body.className.includes("dark") ? "dark" : "default"
+      });
+      initialized = true;
+    }
+
+    let id = 0;
+    for (const codeEl of document.querySelectorAll("pre code.mermaid")) {
+      const preEl = codeEl.parentElement;
+      const graphDefinition = codeEl.textContent;
+      const graphEl = document.createElement("div");
+      const graphId = "mermaid-graph-" + id++;
+      mermaid.render(graphId, graphDefinition).then(({svg, bindFunctions}) => {
+        graphEl.innerHTML = svg;
+        bindFunctions?.(graphEl);
+        preEl.insertAdjacentElement("afterend", graphEl);
+        preEl.remove();
+      });
+    }
+    });
+    </script>
+    """
+  end
+
+  defp before_closing_body_tag(:epub), do: ""
 
   defp dialyzer do
     [

--- a/test/exth/transport/websocket_test.exs
+++ b/test/exth/transport/websocket_test.exs
@@ -15,7 +15,7 @@ defmodule Exth.Transport.WebsocketTest do
     end
 
     test "creates transport with valid options", %{base_opts: base_opts} do
-      expect(Websocket, :start_link, fn _opts -> {:ok, self()} end)
+      expect(Websocket.DynamicSupervisor, :start_websocket, fn _ws_spec -> {:ok, self()} end)
       opts = Keyword.put(base_opts, :rpc_url, @valid_ws_url)
       assert %Websocket{} = Websocket.new(opts)
     end
@@ -86,7 +86,7 @@ defmodule Exth.Transport.WebsocketTest do
     end
 
     test "accepts both ws and wss URLs" do
-      expect(Websocket, :start_link, 2, fn _opts -> {:ok, self()} end)
+      expect(Websocket.DynamicSupervisor, :start_websocket, 2, fn _ws_spec -> {:ok, self()} end)
 
       for url <- [@valid_ws_url, @valid_wss_url] do
         opts = [
@@ -101,7 +101,7 @@ defmodule Exth.Transport.WebsocketTest do
 
   describe "call/2 - sending messages" do
     setup do
-      expect(Websocket, :start_link, fn _opts -> {:ok, self()} end)
+      expect(Websocket.DynamicSupervisor, :start_websocket, fn _ws_spec -> {:ok, self()} end)
 
       {:ok, transport: Websocket.new(rpc_url: @valid_ws_url, dispatch_callback: fn _ -> :ok end)}
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,6 +3,7 @@ Code.require_file("support/test_helpers.exs", __DIR__)
 Mimic.copy(Exth.Rpc.MessageHandler)
 Mimic.copy(Exth.Transport)
 Mimic.copy(Exth.Transport.Websocket)
+Mimic.copy(Exth.Transport.Websocket.DynamicSupervisor)
 
 Mimic.copy(Fresh)
 


### PR DESCRIPTION
**Why:**

So far, we have had no supervision tree for Exth and no registries for its processes.
We need process registries so that we can address processes by name, rather than by PID. This is important because if a process crashes and its supervisor spawns another one, we should be able to find the new process by the same name.
On the other side, we need supervisors so we can create processes under them, and we can have strategies for recovering from crashes. This will make Exth more resilient for sure.
We need to tackle these problems in phases, and we should start with the Transport layer.

**How:**

By:
- adding a `Transport.Registry` that will be responsible for registering all the named processes within the Transport layer;
- adding a `Transport.Websocket.DynamicSupervisor`, that will be responsible for creating `Transport.Websocket` processes on demand.
- adding a `Transport.Supervisor` that will be the top supervisor for the Transport layer and will initialize `Transport.Registry` and `Transport.Websocket.DynamicSupervisor`;

```mermaid
flowchart TD
      A["Exth.Supervisor :one_for_one"] --> B["Transport.Supervisor :one_for_one"]
      B --> C["Transport.Registry"]
      B --> D["Transport.Websocket.DynamicSupervisor :one_for_one"]
      C -.registers.- E["Websocket"]
      D --> E
      E@{ shape: procs}
```
