### PR TITLE
Add IPC transport implementation

### DIFF
--- a/lib/exth/rpc/client.ex
+++ b/lib/exth/rpc/client.ex
@@ -51,13 +51,6 @@ defmodule Exth.Rpc.Client do
       # or
       {:ok, responses} = Client.send(client, [request1, request2])
 
-  ## Client Configuration
-
-  The client accepts the following options:
-
-    * `:rpc_url` - (Required) The endpoint URL
-    * other options that are specific to the transport type
-
   ## Request ID Generation
 
   The client uses Erlang's `:atomics` for thread-safe, monotonic request ID
@@ -103,7 +96,7 @@ defmodule Exth.Rpc.Client do
   alias Exth.Transport
   alias Exth.Transport.Transportable
 
-  @transport_types [:http, :custom, :websocket]
+  @transport_types [:custom, :http, :ipc, :websocket]
 
   @type t :: %__MODULE__{
           counter: :atomics.atomics_ref(),
@@ -115,8 +108,6 @@ defmodule Exth.Rpc.Client do
 
   @spec new(Transport.type(), keyword()) :: t()
   def new(type, opts) when type in @transport_types do
-    validate_required_opts(opts)
-
     case type do
       :websocket ->
         {:ok, handler} = MessageHandler.new(opts[:rpc_url])
@@ -189,11 +180,6 @@ defmodule Exth.Rpc.Client do
   ###
   ### Private Functions
   ###
-
-  @doc false
-  defp validate_required_opts(opts) do
-    opts[:rpc_url] || raise ArgumentError, "missing required option :rpc_url"
-  end
 
   @doc false
   defp do_send(%__MODULE__{} = client, %Request{} = request) do

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -190,16 +190,10 @@ defmodule Exth.Transport do
   """
   @spec new(type(), options()) :: Transportable.t()
   def new(type, opts) do
-    validate_opts(opts)
-
     module = get_transport_module(type, opts)
     transport = struct(module, %{})
 
     Transportable.new(transport, opts)
-  end
-
-  defp validate_opts(opts) do
-    opts[:rpc_url] || raise ArgumentError, "missing required option :rpc_url"
   end
 
   defp get_transport_module(:custom, opts) do
@@ -209,6 +203,7 @@ defmodule Exth.Transport do
   defp get_transport_module(type, opts) do
     case {type, opts[:module]} do
       {:http, nil} -> __MODULE__.Http
+      {:ipc, nil} -> __MODULE__.Ipc
       {:websocket, nil} -> __MODULE__.Websocket
       {_, module} when not is_nil(module) -> module
       _ -> raise ArgumentError, "invalid transport type: #{inspect(type)}"

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -45,18 +45,16 @@ defmodule Exth.Transport do
 
   ## Configuration
 
-  Common options for all transports:
-
-    * `:rpc_url` - (Required) The endpoint URL
-
   HTTP-specific options:
 
+    * `:rpc_url` - The endpoint URL
     * `:headers` - Additional HTTP headers
     * `:timeout` - Request timeout in milliseconds (default: 30000)
     * `:adapter` - Tesla adapter to use (default: Tesla.Adapter.Mint)
 
   WebSocket-specific options:
 
+    * `:rpc_url` - The endpoint URL
     * `:dispatch_callback` - Callback function to handle incoming messages
     * `:module` - Optional custom WebSocket implementation
 

--- a/lib/exth/transport/ipc.ex
+++ b/lib/exth/transport/ipc.ex
@@ -1,0 +1,57 @@
+defmodule Exth.Transport.Ipc do
+  @moduledoc false
+
+  alias __MODULE__.Socket
+
+  defstruct [:path, :socket_opts, :timeout]
+
+  @default_timeout 30_000
+  @default_socket_opts [:binary, active: false, reuseaddr: true]
+
+  def new(opts) do
+    with {:ok, path} <- validate_required_path(opts[:path]) do
+      timeout = opts[:timeout] || @default_timeout
+      socket_opts = opts[:socket_opts] || @default_socket_opts
+
+      %__MODULE__{
+        path: path,
+        socket_opts: socket_opts,
+        timeout: timeout
+      }
+    end
+  end
+
+  def call(%__MODULE__{path: path, socket_opts: socket_opts, timeout: timeout}, request) do
+    case Socket.connect(path, socket_opts) do
+      {:ok, socket} ->
+        try do
+          case Socket.send_request(socket, request, timeout) do
+            {:ok, response} -> {:ok, response}
+            {:error, reason} -> {:error, {:socket_error, reason}}
+          end
+        after
+          Socket.close(socket)
+        end
+
+      {:error, reason} ->
+        {:error, {:connection_error, reason}}
+    end
+  end
+
+  # Private functions
+
+  defp validate_required_path(nil) do
+    raise ArgumentError, "IPC socket path is required but was not provided"
+  end
+
+  defp validate_required_path(path) when not is_binary(path) do
+    raise ArgumentError, "Invalid IPC socket path: expected string, got: #{inspect(path)}"
+  end
+
+  defp validate_required_path(path), do: {:ok, path}
+end
+
+defimpl Exth.Transport.Transportable, for: Exth.Transport.Ipc do
+  def new(_transport, opts), do: Exth.Transport.Ipc.new(opts)
+  def call(transport, request), do: Exth.Transport.Ipc.call(transport, request)
+end

--- a/lib/exth/transport/ipc/socket.ex
+++ b/lib/exth/transport/ipc/socket.ex
@@ -1,0 +1,20 @@
+defmodule Exth.Transport.Ipc.Socket do
+  @moduledoc false
+
+  def connect(path, opts \\ []), do: :gen_tcp.connect({:local, path}, 0, opts)
+
+  def close(socket), do: :gen_tcp.close(socket)
+
+  def send_request(socket, request, timeout) do
+    with :ok <- :gen_tcp.send(socket, request) do
+      receive_response(socket, timeout)
+    end
+  end
+
+  defp receive_response(socket, timeout) do
+    case :gen_tcp.recv(socket, 0, timeout) do
+      {:ok, data} -> {:ok, data}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/test/exth/rpc/client_test.exs
+++ b/test/exth/rpc/client_test.exs
@@ -39,7 +39,7 @@ defmodule Exth.Rpc.ClientTest do
     end
 
     test "fails to create WebSocket client without URL" do
-      assert_raise ArgumentError, "missing required option :rpc_url", fn ->
+      assert_raise ArgumentError, fn ->
         Client.new(:websocket, [])
       end
     end
@@ -50,8 +50,8 @@ defmodule Exth.Rpc.ClientTest do
       end
     end
 
-    test "fails to create client without URL" do
-      assert_raise ArgumentError, "missing required option :rpc_url", fn ->
+    test "fails to create HTTP client without URL" do
+      assert_raise ArgumentError, fn ->
         Client.new(:http, [])
       end
     end

--- a/test/exth/transport/ipc_test.exs
+++ b/test/exth/transport/ipc_test.exs
@@ -1,0 +1,89 @@
+defmodule Exth.Transport.IpcTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Exth.Transport.Ipc
+
+  describe "new/1" do
+    test "creates a new IPC transport with valid path" do
+      transport = Ipc.new(path: "/tmp/test.sock")
+
+      assert %Ipc{
+               path: "/tmp/test.sock",
+               socket_opts: [:binary, active: false, reuseaddr: true],
+               timeout: 30_000
+             } = transport
+    end
+
+    test "creates a new IPC transport with custom options" do
+      transport =
+        Ipc.new(
+          path: "/tmp/custom.sock",
+          timeout: 15_000,
+          socket_opts: [:binary, active: false]
+        )
+
+      assert %Ipc{
+               path: "/tmp/custom.sock",
+               socket_opts: [:binary, active: false],
+               timeout: 15_000
+             } = transport
+    end
+
+    test "raises error when path is not provided" do
+      assert_raise ArgumentError, "IPC socket path is required but was not provided", fn ->
+        Ipc.new([])
+      end
+    end
+
+    test "raises error when path is not a string" do
+      assert_raise ArgumentError, "Invalid IPC socket path: expected string, got: 123", fn ->
+        Ipc.new(path: 123)
+      end
+    end
+  end
+
+  describe "call/2" do
+    test "returns error when socket is not available" do
+      transport = Ipc.new(path: "/tmp/nonexistent.sock")
+      request = Jason.encode!(%{jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: []})
+
+      result = Ipc.call(transport, request)
+
+      assert {:error, {:connection_error, :enoent}} = result
+    end
+
+    test "sends request through socket" do
+      path = "/tmp/test.sock"
+      transport = Ipc.new(path: path)
+
+      request = Jason.encode!(%{jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: []})
+      response = Jason.encode!(%{jsonrpc: "2.0", id: 1, result: "0x1"})
+
+      socket = %{}
+      expect(Ipc.Socket, :connect, fn ^path, _socket_opts -> {:ok, socket} end)
+      expect(Ipc.Socket, :send_request, fn ^socket, ^request, 30_000 -> {:ok, response} end)
+      expect(Ipc.Socket, :close, fn ^socket -> :ok end)
+
+      result = Ipc.call(transport, request)
+
+      assert {:ok, ^response} = result
+    end
+
+    test "returns error when something is wrong with the socket" do
+      path = "/tmp/test.sock"
+      transport = Ipc.new(path: path)
+
+      request = Jason.encode!(%{jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: []})
+
+      socket = %{}
+      expect(Ipc.Socket, :connect, fn ^path, _socket_opts -> {:ok, socket} end)
+      expect(Ipc.Socket, :send_request, fn ^socket, ^request, 30_000 -> {:error, :bad_data} end)
+      expect(Ipc.Socket, :close, fn ^socket -> :ok end)
+
+      result = Ipc.call(transport, request)
+
+      assert {:error, {:socket_error, :bad_data}} = result
+    end
+  end
+end

--- a/test/exth/transport_test.exs
+++ b/test/exth/transport_test.exs
@@ -20,18 +20,6 @@ defmodule Exth.TransportTest do
       assert %TestTransport{} = Transport.new(:custom, valid_custom_transport_opts())
     end
 
-    test "validates base transport requirements" do
-      required_opts = [:rpc_url]
-
-      for opt <- required_opts do
-        opts = valid_transport_opts() |> Keyword.delete(opt)
-
-        assert_raise ArgumentError, ~r/missing required option :#{opt}/, fn ->
-          Transport.new(:http, opts)
-        end
-      end
-    end
-
     test "validates custom transport requirements" do
       assert_raise ArgumentError, ~r/missing required option :module/, fn ->
         Transport.new(:custom, valid_transport_opts())

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@ Code.require_file("support/test_helpers.exs", __DIR__)
 
 Mimic.copy(Exth.Rpc.MessageHandler)
 Mimic.copy(Exth.Transport)
+Mimic.copy(Exth.Transport.Ipc.Socket)
 Mimic.copy(Exth.Transport.Websocket)
 Mimic.copy(Exth.Transport.Websocket.DynamicSupervisor)
 


### PR DESCRIPTION
**Why:**

We were missing IPC transport.

**How:**

By adding an IPC transport implementation using `:gen_tcp`.
We also removed required `:rpc_url` param validation, given that with IPC, that validation does not apply to every transport.

Resolves #29 