### PR TITLE
IPC - Add configurable pool options

### DIFF
--- a/lib/exth/transport/ipc.ex
+++ b/lib/exth/transport/ipc.ex
@@ -1,20 +1,86 @@
 defmodule Exth.Transport.Ipc do
-  @moduledoc false
+  @moduledoc """
+  IPC (Inter-Process Communication) transport implementation for JSON-RPC requests using Unix domain sockets.
+
+  Implements the `Exth.Transport.Transportable` protocol for making IPC connections to JSON-RPC
+  endpoints via Unix domain sockets. Uses NimblePool for connection pooling and efficient
+  resource management.
+
+  ## Features
+
+    * Unix domain socket communication
+    * Connection pooling with NimblePool
+    * Automatic connection management
+    * Configurable pool size and timeouts
+    * Efficient resource utilization
+    * Process registration with via-tuples
+
+  ## Usage
+
+      transport = Transportable.new(
+        %Exth.Transport.Ipc{},
+        path: "/tmp/ethereum.ipc"
+      )
+
+      {:ok, response} = Transportable.call(transport, request)
+
+  ## Configuration
+
+  Required options:
+    * `:path` - The Unix domain socket path (e.g., "/tmp/ethereum.ipc")
+
+  Optional options:
+    * `:timeout` - Request timeout in milliseconds (defaults to 30000)
+    * `:socket_opts` - TCP socket options (defaults to [:binary, active: false, reuseaddr: true])
+    * `:pool_size` - Number of connections in the pool (defaults to 10)
+    * `:pool_lazy_workers` - Whether to create workers lazily (defaults to true)
+    * `:pool_worker_idle_timeout` - Worker idle timeout (defaults to nil)
+    * `:pool_max_idle_pings` - Maximum idle pings before worker termination (defaults to -1)
+
+  ## Connection Pooling
+
+  The IPC transport uses NimblePool to manage a pool of Unix domain socket connections.
+  This provides several benefits:
+
+    * Efficient resource utilization
+    * Automatic connection lifecycle management
+    * Configurable pool size for different workloads
+    * Connection reuse for better performance
+
+  ## Error Handling
+
+  The transport handles several error cases:
+    * Invalid socket path format
+    * Missing required options
+    * Connection failures
+    * Socket communication errors
+    * Pool exhaustion
+
+  See `Exth.Transport.Transportable` for protocol details.
+  """
 
   alias __MODULE__.ConnectionPool
-  # alias __MODULE__.Socket
+
+  @typedoc "IPC transport configuration"
+  @type t :: %__MODULE__{
+          path: String.t(),
+          pool: struct(),
+          socket_opts: list(),
+          timeout: non_neg_integer()
+        }
 
   defstruct [:path, :pool, :socket_opts, :timeout]
 
   @default_timeout 30_000
   @default_socket_opts [:binary, active: false, reuseaddr: true]
 
+  @spec new(keyword()) :: t()
   def new(opts) do
     with {:ok, path} <- validate_required_path(opts[:path]) do
       timeout = opts[:timeout] || @default_timeout
       socket_opts = opts[:socket_opts] || @default_socket_opts
 
-      {:ok, %ConnectionPool{} = pool} = ConnectionPool.start(opts ++ [socket_opts: socket_opts])
+      {:ok, pool} = ConnectionPool.start(opts ++ [socket_opts: socket_opts])
 
       %__MODULE__{
         path: path,
@@ -25,6 +91,7 @@ defmodule Exth.Transport.Ipc do
     end
   end
 
+  @spec call(t(), String.t()) :: {:ok, String.t()} | {:error, term()}
   def call(%__MODULE__{} = transport, request) do
     ConnectionPool.call(transport.pool, request, transport.timeout)
   end

--- a/lib/exth/transport/ipc.ex
+++ b/lib/exth/transport/ipc.ex
@@ -14,11 +14,11 @@ defmodule Exth.Transport.Ipc do
       timeout = opts[:timeout] || @default_timeout
       socket_opts = opts[:socket_opts] || @default_socket_opts
 
-      {:ok, pool_name} = ConnectionPool.start(path: path, socket_opts: socket_opts)
+      {:ok, %ConnectionPool{} = pool} = ConnectionPool.start(opts ++ [socket_opts: socket_opts])
 
       %__MODULE__{
         path: path,
-        pool: pool_name,
+        pool: pool,
         socket_opts: socket_opts,
         timeout: timeout
       }

--- a/lib/exth/transport/ipc/connection_pool.ex
+++ b/lib/exth/transport/ipc/connection_pool.ex
@@ -4,6 +4,8 @@ defmodule Exth.Transport.Ipc.ConnectionPool do
   alias Exth.Transport
   alias Exth.Transport.Ipc
 
+  defstruct [:lazy, :max_idle_pings, :name, :pool_size, :worker, :worker_idle_timeout]
+
   @pool_timeout 30_000
 
   ###
@@ -32,12 +34,12 @@ defmodule Exth.Transport.Ipc.ConnectionPool do
 
     {:ok, _pid} = Ipc.DynamicSupervisor.start_pool({NimblePool, pool_opts})
 
-    {:ok, pool_opts}
+    {:ok, struct(__MODULE__, pool_opts)}
   end
 
-  def call(pool, request, timeout) do
+  def call(%__MODULE__{} = pool, request, timeout) do
     NimblePool.checkout!(
-      pool,
+      pool.name,
       :checkout,
       fn _from, socket ->
         result = send_request(socket, request, timeout)

--- a/lib/exth/transport/ipc/connection_pool.ex
+++ b/lib/exth/transport/ipc/connection_pool.ex
@@ -4,6 +4,16 @@ defmodule Exth.Transport.Ipc.ConnectionPool do
   alias Exth.Transport
   alias Exth.Transport.Ipc
 
+  @typedoc "Connection pool configuration"
+  @type t :: %__MODULE__{
+          lazy: boolean(),
+          max_idle_pings: integer(),
+          name: atom(),
+          pool_size: non_neg_integer(),
+          worker: {module(), term()},
+          worker_idle_timeout: non_neg_integer() | nil
+        }
+
   defstruct [:lazy, :max_idle_pings, :name, :pool_size, :worker, :worker_idle_timeout]
 
   @pool_timeout 30_000
@@ -12,6 +22,30 @@ defmodule Exth.Transport.Ipc.ConnectionPool do
   ### Public API
   ###
 
+  @doc """
+  Starts a new connection pool for the given socket path.
+
+  ## Options
+    * `:path` - (required) The Unix domain socket path
+    * `:socket_opts` - (required) TCP socket options
+    * `:pool_size` - Number of connections in the pool (defaults to 10)
+    * `:pool_lazy_workers` - Whether to create workers lazily (defaults to true)
+    * `:pool_worker_idle_timeout` - Worker idle timeout (defaults to nil)
+    * `:pool_max_idle_pings` - Maximum idle pings before worker termination (defaults to -1)
+
+  ## Returns
+    * `{:ok, pool}` - Successfully started pool
+    * `{:error, reason}` - Failed to start pool
+
+  ## Examples
+
+      {:ok, pool} = ConnectionPool.start(
+        path: "/tmp/ethereum.ipc",
+        socket_opts: [:binary, active: false],
+        pool_size: 5
+      )
+  """
+  @spec start(keyword()) :: {:ok, t()} | {:error, term()}
   def start(opts) do
     path = Keyword.fetch!(opts, :path)
     socket_opts = Keyword.fetch!(opts, :socket_opts)
@@ -37,6 +71,27 @@ defmodule Exth.Transport.Ipc.ConnectionPool do
     {:ok, struct(__MODULE__, pool_opts)}
   end
 
+  @doc """
+  Makes a request through the connection pool.
+
+  Checks out a connection from the pool, sends the request, and returns the response.
+  The connection is automatically returned to the pool after use.
+
+  ## Arguments
+    * `pool` - The connection pool instance
+    * `request` - The JSON-RPC request as a string
+    * `timeout` - Request timeout in milliseconds
+
+  ## Returns
+    * `{:ok, response}` - Successful request with encoded response
+    * `{:error, {:socket_error, reason}}` - Socket communication error
+    * `{:error, reason}` - Other errors (timeout, pool exhaustion, etc)
+
+  ## Examples
+
+      {:ok, response} = ConnectionPool.call(pool, request, 30_000)
+  """
+  @spec call(t(), String.t(), non_neg_integer()) :: {:ok, String.t()} | {:error, term()}
   def call(%__MODULE__{} = pool, request, timeout) do
     NimblePool.checkout!(
       pool.name,


### PR DESCRIPTION
**Why:**

So far we were not able to configure the pool and that essential for being flexible.

**How:**

By allowing to pass options to IPC transport.
Besides this PR also adds docs to IPC modules.