### PR TITLE
Transport - Use init/1 instead of init_transport/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ defmodule MyCustomTransport do
   use Exth.Transport
 
   @impl Exth.Transport
-  def init_transport(opts) do
+  def init(opts) do
     # Initialize your transport
     {:ok, transport_state}
   end

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ end
 ```
 
 **HTTP Features:**
+
 - Built on Tesla HTTP client with middleware support
 - Configurable adapters (Mint, Hackney, etc.)
 - Configurable headers and timeouts
@@ -233,6 +234,7 @@ request = Rpc.request("eth_subscribe", ["newHeads"])
 ```
 
 **WebSocket Features:**
+
 - Full-duplex communication
 - Support for subscriptions and real-time updates
 - Automatic connection management and lifecycle
@@ -269,6 +271,7 @@ request = Rpc.request("eth_blockNumber", [])
 ```
 
 **IPC Features:**
+
 - Unix domain socket communication
 - Connection pooling with NimblePool for efficient resource management
 - Low latency for local nodes
@@ -276,6 +279,7 @@ request = Rpc.request("eth_blockNumber", [])
 - **Note**: Only available on Unix-like systems
 
 **IPC Configuration Options:**
+
 - `:path` - (required) The Unix domain socket path (e.g., "/tmp/ethereum.ipc")
 - `:timeout` - Request timeout in milliseconds (default: 30,000ms)
 - `:socket_opts` - TCP socket options (default: [:binary, active: false, reuseaddr: true])
@@ -294,7 +298,7 @@ defmodule MyCustomTransport do
   use Exth.Transport
 
   @impl Exth.Transport
-  def init_transport(opts, _opts) do
+  def init_transport(opts) do
     # Initialize your transport
     {:ok, transport_state}
   end
@@ -325,6 +329,7 @@ end
 ```
 
 **Custom Transport Features:**
+
 - Full control over transport implementation
 - Custom state management
 - Behaviour-based implementation for consistency

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -45,7 +45,7 @@ defmodule Exth.Transport do
         use Exth.Transport
 
         @impl Exth.Transport
-        def init_transport(opts) do
+        def init(opts) do
           # Initialize your transport
           {:ok, transport_state}
         end
@@ -99,7 +99,7 @@ defmodule Exth.Transport do
   ### Behaviour callbacks
   ###
 
-  @callback init_transport(transport_options()) :: {:ok, adapter_config()} | {:error, term()}
+  @callback init(transport_options()) :: {:ok, adapter_config()} | {:error, term()}
 
   @callback handle_request(transport_state :: adapter_config(), request :: String.t()) ::
               request_response()
@@ -138,7 +138,7 @@ defmodule Exth.Transport do
   @spec new(type(), transport_options()) :: {:ok, t()} | {:error, term()}
   def new(type, opts) when type in @transport_types do
     with {:ok, adapter} <- fetch_transport_module(type, opts),
-         {:ok, adapter_config} <- adapter.init_transport(opts) do
+         {:ok, adapter_config} <- adapter.init(opts) do
       {:ok, %__MODULE__{adapter: adapter, adapter_config: adapter_config}}
     end
   end

--- a/lib/exth/transport.ex
+++ b/lib/exth/transport.ex
@@ -45,7 +45,7 @@ defmodule Exth.Transport do
         use Exth.Transport
 
         @impl Exth.Transport
-        def init_transport(opts, supervisor, registry) do
+        def init_transport(opts) do
           # Initialize your transport
           {:ok, transport_state}
         end
@@ -82,7 +82,6 @@ defmodule Exth.Transport do
   @type type :: unquote(@transport_type)
 
   @type transport_options() :: keyword()
-  @type options :: [supervisor: pid(), registry: pid()]
   @type request_response :: :ok | {:ok, String.t()} | {:error, term()}
 
   ###
@@ -100,8 +99,7 @@ defmodule Exth.Transport do
   ### Behaviour callbacks
   ###
 
-  @callback init_transport(transport_options(), options()) ::
-              {:ok, adapter_config()} | {:error, term()}
+  @callback init_transport(transport_options()) :: {:ok, adapter_config()} | {:error, term()}
 
   @callback handle_request(transport_state :: adapter_config(), request :: String.t()) ::
               request_response()
@@ -140,7 +138,7 @@ defmodule Exth.Transport do
   @spec new(type(), transport_options()) :: {:ok, t()} | {:error, term()}
   def new(type, opts) when type in @transport_types do
     with {:ok, adapter} <- fetch_transport_module(type, opts),
-         {:ok, adapter_config} <- adapter.init_transport(opts, []) do
+         {:ok, adapter_config} <- adapter.init_transport(opts) do
       {:ok, %__MODULE__{adapter: adapter, adapter_config: adapter_config}}
     end
   end

--- a/lib/exth/transport/http.ex
+++ b/lib/exth/transport/http.ex
@@ -55,10 +55,10 @@ defmodule Exth.Transport.Http do
   end
 
   @impl true
-  def init_transport(custom_opts, _opts) do
-    with {:ok, rpc_url} <- validate_required_url(custom_opts[:rpc_url]),
+  def init_transport(opts) do
+    with {:ok, rpc_url} <- validate_required_url(opts[:rpc_url]),
          :ok <- validate_url_format(rpc_url),
-         client <- build_client(custom_opts, rpc_url) do
+         client <- build_client(opts, rpc_url) do
       {:ok, %__MODULE__{client: client}}
     end
   end

--- a/lib/exth/transport/http.ex
+++ b/lib/exth/transport/http.ex
@@ -55,7 +55,7 @@ defmodule Exth.Transport.Http do
   end
 
   @impl true
-  def init_transport(opts) do
+  def init(opts) do
     with {:ok, rpc_url} <- validate_required_url(opts[:rpc_url]),
          :ok <- validate_url_format(rpc_url),
          client <- build_client(opts, rpc_url) do

--- a/lib/exth/transport/ipc.ex
+++ b/lib/exth/transport/ipc.ex
@@ -67,7 +67,7 @@ defmodule Exth.Transport.Ipc do
   @default_socket_opts [:binary, active: false, reuseaddr: true]
 
   @impl true
-  def init_transport(opts) do
+  def init(opts) do
     with {:ok, path} <- validate_required_path(opts[:path]) do
       timeout = opts[:timeout] || @default_timeout
       socket_opts = opts[:socket_opts] || @default_socket_opts

--- a/lib/exth/transport/ipc.ex
+++ b/lib/exth/transport/ipc.ex
@@ -67,12 +67,12 @@ defmodule Exth.Transport.Ipc do
   @default_socket_opts [:binary, active: false, reuseaddr: true]
 
   @impl true
-  def init_transport(transport_opts, _opts) do
-    with {:ok, path} <- validate_required_path(transport_opts[:path]) do
-      timeout = transport_opts[:timeout] || @default_timeout
-      socket_opts = transport_opts[:socket_opts] || @default_socket_opts
+  def init_transport(opts) do
+    with {:ok, path} <- validate_required_path(opts[:path]) do
+      timeout = opts[:timeout] || @default_timeout
+      socket_opts = opts[:socket_opts] || @default_socket_opts
 
-      {:ok, pool} = ConnectionPool.start(transport_opts ++ [socket_opts: socket_opts])
+      {:ok, pool} = ConnectionPool.start(opts ++ [socket_opts: socket_opts])
 
       {:ok,
        %__MODULE__{

--- a/lib/exth/transport/websocket.ex
+++ b/lib/exth/transport/websocket.ex
@@ -70,11 +70,11 @@ defmodule Exth.Transport.Websocket do
   end
 
   @impl Exth.Transport
-  def init_transport(transport_opts, _opts) do
-    with {:ok, rpc_url} <- validate_required_url(transport_opts[:rpc_url]),
+  def init_transport(opts) do
+    with {:ok, rpc_url} <- validate_required_url(opts[:rpc_url]),
          :ok <- validate_url_format(rpc_url),
          {:ok, dispatch_callback} <-
-           validate_required_dispatch_callback(transport_opts[:dispatch_callback]) do
+           validate_required_dispatch_callback(opts[:dispatch_callback]) do
       name = via_tuple(rpc_url)
 
       child_spec = {

--- a/lib/exth/transport/websocket.ex
+++ b/lib/exth/transport/websocket.ex
@@ -70,7 +70,7 @@ defmodule Exth.Transport.Websocket do
   end
 
   @impl Exth.Transport
-  def init_transport(opts) do
+  def init(opts) do
     with {:ok, rpc_url} <- validate_required_url(opts[:rpc_url]),
          :ok <- validate_url_format(rpc_url),
          {:ok, dispatch_callback} <-

--- a/test/exth/transport/http_test.exs
+++ b/test/exth/transport/http_test.exs
@@ -18,23 +18,23 @@ defmodule Exth.Transport.HttpTest do
     }
   end
 
-  describe "init_transport/1 - transport initialization" do
+  describe "init/1 - transport initialization" do
     test "creates transport with valid options", %{opts: opts} do
-      assert {:ok, %Http{client: %Tesla.Client{}}} = Http.init_transport(opts)
+      assert {:ok, %Http{client: %Tesla.Client{}}} = Http.init(opts)
     end
 
     test "validates required RPC URL", %{opts: opts} do
       opts = Keyword.delete(opts, :rpc_url)
 
       assert {:error, "RPC URL is required but was not provided"} =
-               Http.init_transport(opts)
+               Http.init(opts)
     end
 
     test "returns error when RPC URL is not a string", %{opts: opts} do
       opts = Keyword.put(opts, :rpc_url, 123)
 
       assert {:error, "Invalid RPC URL format: expected string, got: 123"} =
-               Http.init_transport(opts)
+               Http.init(opts)
     end
 
     test "returns error when RPC URL has an invalid scheme", %{opts: opts} do
@@ -42,27 +42,27 @@ defmodule Exth.Transport.HttpTest do
 
       assert {:error,
               "Invalid RPC URL format: \"ftp://example.com\". The URL must start with http:// or https://"} =
-               Http.init_transport(opts)
+               Http.init(opts)
     end
 
     test "returns error when RPC URL has no host", %{opts: opts} do
       opts = Keyword.put(opts, :rpc_url, "http://")
 
       assert {:error, "Invalid RPC URL format: \"http://\". The URL must contain a valid host"} =
-               Http.init_transport(opts)
+               Http.init(opts)
     end
 
     test "accepts custom headers", %{opts: opts} do
       opts = Keyword.put(opts, :headers, [{"x-api-key", "test"}])
 
-      assert {:ok, transport} = Http.init_transport(opts)
+      assert {:ok, transport} = Http.init(opts)
       assert %Tesla.Client{pre: pre} = transport.client
       {_, :call, [headers]} = find_middleware(pre, Tesla.Middleware.Headers)
       assert {"x-api-key", "test"} in headers
     end
 
     test "sets default headers", %{opts: opts} do
-      assert {:ok, transport} = Http.init_transport(opts)
+      assert {:ok, transport} = Http.init(opts)
 
       %Tesla.Client{pre: pre} = transport.client
       {_, :call, [headers]} = find_middleware(pre, Tesla.Middleware.Headers)
@@ -75,7 +75,7 @@ defmodule Exth.Transport.HttpTest do
       timeout = 5_000
       opts = Keyword.put(opts, :timeout, timeout)
 
-      assert {:ok, transport} = Http.init_transport(opts)
+      assert {:ok, transport} = Http.init(opts)
 
       %Tesla.Client{pre: pre} = transport.client
       {_, :call, [middleware]} = find_middleware(pre, Tesla.Middleware.Timeout)
@@ -86,7 +86,7 @@ defmodule Exth.Transport.HttpTest do
   describe "handle_request/2 - RPC requests" do
     setup %{opts: opts} do
       opts = Keyword.put(opts, :adapter, MockAdapter)
-      {:ok, transport} = Http.init_transport(opts)
+      {:ok, transport} = Http.init(opts)
       {:ok, transport: transport}
     end
 
@@ -159,7 +159,7 @@ defmodule Exth.Transport.HttpTest do
         |> Keyword.put(:adapter, MockAdapter)
         |> Keyword.put(:timeout, 100)
 
-      {:ok, transport} = Http.init_transport(opts)
+      {:ok, transport} = Http.init(opts)
 
       MockAdapter.mock(fn %{method: :post} ->
         Process.sleep(200)

--- a/test/exth/transport/http_test.exs
+++ b/test/exth/transport/http_test.exs
@@ -12,73 +12,57 @@ defmodule Exth.Transport.HttpTest do
 
   setup_all do
     %{
-      transport_opts: valid_transport_opts(),
-      opts: [],
+      opts: valid_transport_opts(),
       sample_request: Request.new("eth_blockNumber", [], 1) |> Request.serialize(),
       known_methods: Exth.TestTransport.get_known_methods()
     }
   end
 
   describe "init_transport/1 - transport initialization" do
-    test "creates transport with valid options", %{transport_opts: transport_opts, opts: opts} do
-      assert {:ok, %Http{client: %Tesla.Client{}}} = Http.init_transport(transport_opts, opts)
+    test "creates transport with valid options", %{opts: opts} do
+      assert {:ok, %Http{client: %Tesla.Client{}}} = Http.init_transport(opts)
     end
 
-    test "validates required RPC URL", %{transport_opts: transport_opts, opts: opts} do
-      transport_opts = Keyword.delete(transport_opts, :rpc_url)
+    test "validates required RPC URL", %{opts: opts} do
+      opts = Keyword.delete(opts, :rpc_url)
 
       assert {:error, "RPC URL is required but was not provided"} =
-               Http.init_transport(transport_opts, opts)
+               Http.init_transport(opts)
     end
 
-    test "returns error when RPC URL is not a string", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :rpc_url, 123)
+    test "returns error when RPC URL is not a string", %{opts: opts} do
+      opts = Keyword.put(opts, :rpc_url, 123)
 
       assert {:error, "Invalid RPC URL format: expected string, got: 123"} =
-               Http.init_transport(transport_opts, opts)
+               Http.init_transport(opts)
     end
 
-    test "returns error when RPC URL has an invalid scheme", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :rpc_url, "ftp://example.com")
+    test "returns error when RPC URL has an invalid scheme", %{opts: opts} do
+      opts = Keyword.put(opts, :rpc_url, "ftp://example.com")
 
       assert {:error,
               "Invalid RPC URL format: \"ftp://example.com\". The URL must start with http:// or https://"} =
-               Http.init_transport(transport_opts, opts)
+               Http.init_transport(opts)
     end
 
-    test "returns error when RPC URL has no host", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :rpc_url, "http://")
+    test "returns error when RPC URL has no host", %{opts: opts} do
+      opts = Keyword.put(opts, :rpc_url, "http://")
 
       assert {:error, "Invalid RPC URL format: \"http://\". The URL must contain a valid host"} =
-               Http.init_transport(transport_opts, opts)
+               Http.init_transport(opts)
     end
 
-    test "accepts custom headers", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :headers, [{"x-api-key", "test"}])
+    test "accepts custom headers", %{opts: opts} do
+      opts = Keyword.put(opts, :headers, [{"x-api-key", "test"}])
 
-      assert {:ok, transport} = Http.init_transport(transport_opts, opts)
+      assert {:ok, transport} = Http.init_transport(opts)
       assert %Tesla.Client{pre: pre} = transport.client
       {_, :call, [headers]} = find_middleware(pre, Tesla.Middleware.Headers)
       assert {"x-api-key", "test"} in headers
     end
 
-    test "sets default headers", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      assert {:ok, transport} = Http.init_transport(transport_opts, opts)
+    test "sets default headers", %{opts: opts} do
+      assert {:ok, transport} = Http.init_transport(opts)
 
       %Tesla.Client{pre: pre} = transport.client
       {_, :call, [headers]} = find_middleware(pre, Tesla.Middleware.Headers)
@@ -87,11 +71,11 @@ defmodule Exth.Transport.HttpTest do
       assert {"user-agent", _} = Enum.find(headers, &(elem(&1, 0) == "user-agent"))
     end
 
-    test "accepts custom timeout", %{transport_opts: transport_opts, opts: opts} do
+    test "accepts custom timeout", %{opts: opts} do
       timeout = 5_000
-      transport_opts = Keyword.put(transport_opts, :timeout, timeout)
+      opts = Keyword.put(opts, :timeout, timeout)
 
-      assert {:ok, transport} = Http.init_transport(transport_opts, opts)
+      assert {:ok, transport} = Http.init_transport(opts)
 
       %Tesla.Client{pre: pre} = transport.client
       {_, :call, [middleware]} = find_middleware(pre, Tesla.Middleware.Timeout)
@@ -100,9 +84,9 @@ defmodule Exth.Transport.HttpTest do
   end
 
   describe "handle_request/2 - RPC requests" do
-    setup %{transport_opts: transport_opts, opts: opts} do
-      transport_opts = Keyword.put(transport_opts, :adapter, MockAdapter)
-      {:ok, transport} = Http.init_transport(transport_opts, opts)
+    setup %{opts: opts} do
+      opts = Keyword.put(opts, :adapter, MockAdapter)
+      {:ok, transport} = Http.init_transport(opts)
       {:ok, transport: transport}
     end
 
@@ -167,16 +151,15 @@ defmodule Exth.Transport.HttpTest do
     end
 
     test "handles timeout with custom timeout value", %{
-      transport_opts: transport_opts,
       opts: opts,
       sample_request: request
     } do
-      transport_opts =
-        transport_opts
+      opts =
+        opts
         |> Keyword.put(:adapter, MockAdapter)
         |> Keyword.put(:timeout, 100)
 
-      {:ok, transport} = Http.init_transport(transport_opts, opts)
+      {:ok, transport} = Http.init_transport(opts)
 
       MockAdapter.mock(fn %{method: :post} ->
         Process.sleep(200)

--- a/test/exth/transport/ipc_test.exs
+++ b/test/exth/transport/ipc_test.exs
@@ -4,7 +4,7 @@ defmodule Exth.Transport.IpcTest do
 
   alias Exth.Transport.Ipc
 
-  describe "init_transport/2 - transport initialization" do
+  describe "init/2 - transport initialization" do
     setup do
       %{
         opts: [path: "/tmp/test.sock"]
@@ -15,7 +15,7 @@ defmodule Exth.Transport.IpcTest do
       pool = %Ipc.ConnectionPool{name: "pool_name"}
       expect(Ipc.ConnectionPool, :start, fn _opts -> {:ok, pool} end)
 
-      {:ok, transport} = Ipc.init_transport(opts)
+      {:ok, transport} = Ipc.init(opts)
 
       assert %Ipc{
                path: "/tmp/test.sock",
@@ -35,7 +35,7 @@ defmodule Exth.Transport.IpcTest do
         socket_opts: [:binary, active: false]
       ]
 
-      {:ok, transport} = Ipc.init_transport(opts)
+      {:ok, transport} = Ipc.init(opts)
 
       assert %Ipc{
                path: "/tmp/custom.sock",
@@ -49,14 +49,14 @@ defmodule Exth.Transport.IpcTest do
       opts = Keyword.delete(opts, :path)
 
       assert {:error, "IPC socket path is required but was not provided"} =
-               Ipc.init_transport(opts)
+               Ipc.init(opts)
     end
 
     test "raises error when path is not a string", %{opts: opts} do
       opts = Keyword.put(opts, :path, 123)
 
       assert {:error, "Invalid IPC socket path: expected string, got: 123"} =
-               Ipc.init_transport(opts)
+               Ipc.init(opts)
     end
   end
 
@@ -66,7 +66,7 @@ defmodule Exth.Transport.IpcTest do
       pool = %Ipc.ConnectionPool{name: "pool_name"}
       expect(Ipc.ConnectionPool, :start, fn _opts -> {:ok, pool} end)
 
-      {:ok, transport} = Ipc.init_transport(path: path)
+      {:ok, transport} = Ipc.init(path: path)
 
       {:ok, transport: transport, pool: pool}
     end

--- a/test/exth/transport/ipc_test.exs
+++ b/test/exth/transport/ipc_test.exs
@@ -7,19 +7,15 @@ defmodule Exth.Transport.IpcTest do
   describe "init_transport/2 - transport initialization" do
     setup do
       %{
-        transport_opts: [path: "/tmp/test.sock"],
-        opts: []
+        opts: [path: "/tmp/test.sock"]
       }
     end
 
-    test "creates a new IPC transport with valid path", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
+    test "creates a new IPC transport with valid path", %{opts: opts} do
       pool = %Ipc.ConnectionPool{name: "pool_name"}
       expect(Ipc.ConnectionPool, :start, fn _opts -> {:ok, pool} end)
 
-      {:ok, transport} = Ipc.init_transport(transport_opts, opts)
+      {:ok, transport} = Ipc.init_transport(opts)
 
       assert %Ipc{
                path: "/tmp/test.sock",
@@ -29,17 +25,17 @@ defmodule Exth.Transport.IpcTest do
              } = transport
     end
 
-    test "creates a new IPC transport with custom options", %{opts: opts} do
+    test "creates a new IPC transport with custom options" do
       pool = %Ipc.ConnectionPool{name: "pool_name"}
       expect(Ipc.ConnectionPool, :start, fn _opts -> {:ok, pool} end)
 
-      transport_opts = [
+      opts = [
         path: "/tmp/custom.sock",
         timeout: 15_000,
         socket_opts: [:binary, active: false]
       ]
 
-      {:ok, transport} = Ipc.init_transport(transport_opts, opts)
+      {:ok, transport} = Ipc.init_transport(opts)
 
       assert %Ipc{
                path: "/tmp/custom.sock",
@@ -49,18 +45,18 @@ defmodule Exth.Transport.IpcTest do
              } = transport
     end
 
-    test "raises error when path is not provided", %{transport_opts: transport_opts, opts: opts} do
-      transport_opts = Keyword.delete(transport_opts, :path)
+    test "raises error when path is not provided", %{opts: opts} do
+      opts = Keyword.delete(opts, :path)
 
       assert {:error, "IPC socket path is required but was not provided"} =
-               Ipc.init_transport(transport_opts, opts)
+               Ipc.init_transport(opts)
     end
 
-    test "raises error when path is not a string", %{transport_opts: transport_opts, opts: opts} do
-      transport_opts = Keyword.put(transport_opts, :path, 123)
+    test "raises error when path is not a string", %{opts: opts} do
+      opts = Keyword.put(opts, :path, 123)
 
       assert {:error, "Invalid IPC socket path: expected string, got: 123"} =
-               Ipc.init_transport(transport_opts, opts)
+               Ipc.init_transport(opts)
     end
   end
 
@@ -70,7 +66,7 @@ defmodule Exth.Transport.IpcTest do
       pool = %Ipc.ConnectionPool{name: "pool_name"}
       expect(Ipc.ConnectionPool, :start, fn _opts -> {:ok, pool} end)
 
-      {:ok, transport} = Ipc.init_transport([path: path], [])
+      {:ok, transport} = Ipc.init_transport(path: path)
 
       {:ok, transport: transport, pool: pool}
     end

--- a/test/exth/transport/websocket_test.exs
+++ b/test/exth/transport/websocket_test.exs
@@ -9,7 +9,7 @@ defmodule Exth.Transport.WebsocketTest do
 
   setup :verify_on_exit!
 
-  describe "init_transport/2 - transport initialization" do
+  describe "init/2 - transport initialization" do
     setup do
       %{
         opts: [rpc_url: @valid_ws_url, dispatch_callback: fn arg -> arg end]
@@ -18,14 +18,14 @@ defmodule Exth.Transport.WebsocketTest do
 
     test "creates transport with valid options", %{opts: opts} do
       expect(Websocket.DynamicSupervisor, :start_websocket, fn _ws_spec -> {:ok, self()} end)
-      assert {:ok, %Websocket{}} = Websocket.init_transport(opts)
+      assert {:ok, %Websocket{}} = Websocket.init(opts)
     end
 
     test "validates required RPC URL", %{opts: opts} do
       opts = Keyword.delete(opts, :rpc_url)
 
       assert {:error, "RPC URL is required but was not provided"} =
-               Websocket.init_transport(opts)
+               Websocket.init(opts)
     end
 
     test "raises when RPC URL is not a string", %{opts: opts} do
@@ -41,7 +41,7 @@ defmodule Exth.Transport.WebsocketTest do
         opts = Keyword.put(opts, :rpc_url, url)
 
         assert {:error, reason} =
-                 Websocket.init_transport(opts)
+                 Websocket.init(opts)
 
         assert reason =~ "Invalid RPC URL: expected string, got:"
       end
@@ -52,21 +52,21 @@ defmodule Exth.Transport.WebsocketTest do
 
       assert {:error,
               "Invalid RPC URL format: \"ftp://example.com\". The URL must start with ws:// or wss://"} =
-               Websocket.init_transport(opts)
+               Websocket.init(opts)
     end
 
     test "returns error when RPC URL has no host", %{opts: opts} do
       opts = Keyword.put(opts, :rpc_url, "wss://")
 
       assert {:error, "Invalid RPC URL format: \"wss://\". The URL must contain a valid host"} =
-               Websocket.init_transport(opts)
+               Websocket.init(opts)
     end
 
     test "raises when no dispatch callback is provided", %{opts: opts} do
       opts = Keyword.delete(opts, :dispatch_callback)
 
       assert {:error, "Dispatcher callback function is required but was not provided"} =
-               Websocket.init_transport(opts)
+               Websocket.init(opts)
     end
 
     test "raises when dispatch_callback is not a function", %{opts: opts} do
@@ -74,13 +74,13 @@ defmodule Exth.Transport.WebsocketTest do
 
       assert {:error,
               "Invalid dispatch_callback function: expected function with arity 1, got: \"not a function\""} =
-               Websocket.init_transport(opts)
+               Websocket.init(opts)
     end
 
     test "raises when dispatch_callback arity is not 1", %{opts: opts} do
       opts = Keyword.put(opts, :dispatch_callback, fn -> :ok end)
 
-      assert {:error, message} = Websocket.init_transport(opts)
+      assert {:error, message} = Websocket.init(opts)
       assert message =~ "Invalid dispatch_callback function: expected function with arity 1, got:"
     end
 
@@ -89,7 +89,7 @@ defmodule Exth.Transport.WebsocketTest do
 
       for url <- [@valid_ws_url, @valid_wss_url] do
         opts = Keyword.put(opts, :rpc_url, url)
-        assert {:ok, %Websocket{}} = Websocket.init_transport(opts)
+        assert {:ok, %Websocket{}} = Websocket.init(opts)
       end
     end
   end
@@ -99,7 +99,7 @@ defmodule Exth.Transport.WebsocketTest do
       expect(Websocket.DynamicSupervisor, :start_websocket, fn _ws_spec -> {:ok, self()} end)
 
       opts = [rpc_url: @valid_ws_url, dispatch_callback: fn _ -> :ok end]
-      {:ok, transport} = Websocket.init_transport(opts)
+      {:ok, transport} = Websocket.init(opts)
       {:ok, transport: transport}
     end
 

--- a/test/exth/transport/websocket_test.exs
+++ b/test/exth/transport/websocket_test.exs
@@ -12,24 +12,23 @@ defmodule Exth.Transport.WebsocketTest do
   describe "init_transport/2 - transport initialization" do
     setup do
       %{
-        transport_opts: [rpc_url: @valid_ws_url, dispatch_callback: fn arg -> arg end],
-        opts: []
+        opts: [rpc_url: @valid_ws_url, dispatch_callback: fn arg -> arg end]
       }
     end
 
-    test "creates transport with valid options", %{transport_opts: transport_opts, opts: opts} do
+    test "creates transport with valid options", %{opts: opts} do
       expect(Websocket.DynamicSupervisor, :start_websocket, fn _ws_spec -> {:ok, self()} end)
-      assert {:ok, %Websocket{}} = Websocket.init_transport(transport_opts, opts)
+      assert {:ok, %Websocket{}} = Websocket.init_transport(opts)
     end
 
-    test "validates required RPC URL", %{transport_opts: transport_opts, opts: opts} do
-      transport_opts = Keyword.delete(transport_opts, :rpc_url)
+    test "validates required RPC URL", %{opts: opts} do
+      opts = Keyword.delete(opts, :rpc_url)
 
       assert {:error, "RPC URL is required but was not provided"} =
-               Websocket.init_transport(transport_opts, opts)
+               Websocket.init_transport(opts)
     end
 
-    test "raises when RPC URL is not a string", %{transport_opts: transport_opts, opts: opts} do
+    test "raises when RPC URL is not a string", %{opts: opts} do
       invalid_urls = [
         123,
         %{},
@@ -39,76 +38,58 @@ defmodule Exth.Transport.WebsocketTest do
       ]
 
       for url <- invalid_urls do
-        transport_opts = Keyword.put(transport_opts, :rpc_url, url)
+        opts = Keyword.put(opts, :rpc_url, url)
 
         assert {:error, reason} =
-                 Websocket.init_transport(transport_opts, opts)
+                 Websocket.init_transport(opts)
 
         assert reason =~ "Invalid RPC URL: expected string, got:"
       end
     end
 
-    test "returns error when RPC URL has an invalid scheme", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :rpc_url, "ftp://example.com")
+    test "returns error when RPC URL has an invalid scheme", %{opts: opts} do
+      opts = Keyword.put(opts, :rpc_url, "ftp://example.com")
 
       assert {:error,
               "Invalid RPC URL format: \"ftp://example.com\". The URL must start with ws:// or wss://"} =
-               Websocket.init_transport(transport_opts, opts)
+               Websocket.init_transport(opts)
     end
 
-    test "returns error when RPC URL has no host", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :rpc_url, "wss://")
+    test "returns error when RPC URL has no host", %{opts: opts} do
+      opts = Keyword.put(opts, :rpc_url, "wss://")
 
       assert {:error, "Invalid RPC URL format: \"wss://\". The URL must contain a valid host"} =
-               Websocket.init_transport(transport_opts, opts)
+               Websocket.init_transport(opts)
     end
 
-    test "raises when no dispatch callback is provided", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.delete(transport_opts, :dispatch_callback)
+    test "raises when no dispatch callback is provided", %{opts: opts} do
+      opts = Keyword.delete(opts, :dispatch_callback)
 
       assert {:error, "Dispatcher callback function is required but was not provided"} =
-               Websocket.init_transport(transport_opts, opts)
+               Websocket.init_transport(opts)
     end
 
-    test "raises when dispatch_callback is not a function", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :dispatch_callback, "not a function")
+    test "raises when dispatch_callback is not a function", %{opts: opts} do
+      opts = Keyword.put(opts, :dispatch_callback, "not a function")
 
       assert {:error,
               "Invalid dispatch_callback function: expected function with arity 1, got: \"not a function\""} =
-               Websocket.init_transport(transport_opts, opts)
+               Websocket.init_transport(opts)
     end
 
-    test "raises when dispatch_callback arity is not 1", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
-      transport_opts = Keyword.put(transport_opts, :dispatch_callback, fn -> :ok end)
+    test "raises when dispatch_callback arity is not 1", %{opts: opts} do
+      opts = Keyword.put(opts, :dispatch_callback, fn -> :ok end)
 
-      assert {:error, message} = Websocket.init_transport(transport_opts, opts)
+      assert {:error, message} = Websocket.init_transport(opts)
       assert message =~ "Invalid dispatch_callback function: expected function with arity 1, got:"
     end
 
-    test "accepts both ws and wss URLs", %{
-      transport_opts: transport_opts,
-      opts: opts
-    } do
+    test "accepts both ws and wss URLs", %{opts: opts} do
       expect(Websocket.DynamicSupervisor, :start_websocket, 2, fn _ws_spec -> {:ok, self()} end)
 
       for url <- [@valid_ws_url, @valid_wss_url] do
-        transport_opts = Keyword.put(transport_opts, :rpc_url, url)
-        assert {:ok, %Websocket{}} = Websocket.init_transport(transport_opts, opts)
+        opts = Keyword.put(opts, :rpc_url, url)
+        assert {:ok, %Websocket{}} = Websocket.init_transport(opts)
       end
     end
   end
@@ -117,9 +98,8 @@ defmodule Exth.Transport.WebsocketTest do
     setup do
       expect(Websocket.DynamicSupervisor, :start_websocket, fn _ws_spec -> {:ok, self()} end)
 
-      transport_opts = [rpc_url: @valid_ws_url, dispatch_callback: fn _ -> :ok end]
-      opts = []
-      {:ok, transport} = Websocket.init_transport(transport_opts, opts)
+      opts = [rpc_url: @valid_ws_url, dispatch_callback: fn _ -> :ok end]
+      {:ok, transport} = Websocket.init_transport(opts)
       {:ok, transport: transport}
     end
 

--- a/test/support/stubs/async_test_transport.ex
+++ b/test/support/stubs/async_test_transport.ex
@@ -6,7 +6,7 @@ defmodule Exth.AsyncTestTransport do
   defstruct [:config]
 
   @impl Exth.Transport
-  def init_transport(opts, _opts) do
+  def init_transport(opts) do
     {:ok, %Exth.AsyncTestTransport{config: opts}}
   end
 

--- a/test/support/stubs/async_test_transport.ex
+++ b/test/support/stubs/async_test_transport.ex
@@ -6,7 +6,7 @@ defmodule Exth.AsyncTestTransport do
   defstruct [:config]
 
   @impl Exth.Transport
-  def init_transport(opts) do
+  def init(opts) do
     {:ok, %Exth.AsyncTestTransport{config: opts}}
   end
 

--- a/test/support/stubs/test_transport.ex
+++ b/test/support/stubs/test_transport.ex
@@ -16,7 +16,7 @@ defmodule Exth.TestTransport do
   def get_known_methods, do: @known_methods
 
   @impl Exth.Transport
-  def init_transport(opts) do
+  def init(opts) do
     {:ok, %__MODULE__{config: opts}}
   end
 

--- a/test/support/stubs/test_transport.ex
+++ b/test/support/stubs/test_transport.ex
@@ -16,7 +16,7 @@ defmodule Exth.TestTransport do
   def get_known_methods, do: @known_methods
 
   @impl Exth.Transport
-  def init_transport(opts, _opts) do
+  def init_transport(opts) do
     {:ok, %__MODULE__{config: opts}}
   end
 

--- a/test/support/stubs/transport_error_test_transport.ex
+++ b/test/support/stubs/transport_error_test_transport.ex
@@ -5,7 +5,7 @@ defmodule Exth.TransportErrorTestTransport do
   defstruct [:config]
 
   @impl Exth.Transport
-  def init_transport(opts) do
+  def init(opts) do
     {:ok, %Exth.TransportErrorTestTransport{config: opts}}
   end
 

--- a/test/support/stubs/transport_error_test_transport.ex
+++ b/test/support/stubs/transport_error_test_transport.ex
@@ -5,7 +5,7 @@ defmodule Exth.TransportErrorTestTransport do
   defstruct [:config]
 
   @impl Exth.Transport
-  def init_transport(opts, _opts) do
+  def init_transport(opts) do
     {:ok, %Exth.TransportErrorTestTransport{config: opts}}
   end
 


### PR DESCRIPTION
**Why:**

It's odd to use `init_transport/2` when the second argument is just another set of options, for instance, a supervisor and a registry.
`init/1` is just more conventional and fits better in this case.

**How:**

By updating all `init_transport/2` references to `init/1`.